### PR TITLE
fix: abort hung OpenAI chat and tool fetches

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -246,7 +246,7 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   console.log("openai fetch timeout ok: chat and tool fetches pass AbortSignal");
 
   const previousHeaderMs = openAITimeouts.headerMs;
-  const previousIdleMs = openAITimeouts.streamIdleMs;
+  const previousIdleMs = openAITimeouts.bodyIdleMs;
   openAITimeouts.headerMs = 20;
   try {
     await withMockNetwork(
@@ -314,8 +314,40 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   console.log("openai fetch timeout ok: hung chat and tool fetches abort");
 
   openAITimeouts.headerMs = 30;
-  openAITimeouts.streamIdleMs = 80;
+  openAITimeouts.bodyIdleMs = 80;
   try {
+    let toolBodyCancelled = false;
+    await withMockNetwork(
+      async (url) => {
+        if (!url.includes("api.openai.com/v1/chat/completions")) {
+          return new Response("missing", { status: 404 });
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"choices":['));
+            },
+            cancel() {
+              toolBodyCancelled = true;
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      },
+      async () => {
+        let idleTimedOut = false;
+        try {
+          await openAI(env, messages, true);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.includes("idle timed out")) throw error;
+          idleTimedOut = true;
+        }
+        if (!idleTimedOut) throw new Error("OpenAI tool response body idle timeout did not fire");
+      },
+    );
+    if (!toolBodyCancelled) throw new Error("OpenAI timed-out tool response was not cancelled");
+
     await withMockNetwork(
       async (url) => {
         if (!url.includes("api.openai.com/v1/chat/completions")) {
@@ -349,7 +381,7 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
     );
 
     openAITimeouts.headerMs = 40;
-    openAITimeouts.streamIdleMs = 200;
+    openAITimeouts.bodyIdleMs = 200;
     await withMockNetwork(
       async (url) => {
         if (!url.includes("api.openai.com/v1/chat/completions")) {
@@ -385,9 +417,11 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
     );
   } finally {
     openAITimeouts.headerMs = previousHeaderMs;
-    openAITimeouts.streamIdleMs = previousIdleMs;
+    openAITimeouts.bodyIdleMs = previousIdleMs;
   }
-  console.log("openai fetch timeout ok: header deadline does not cut a healthy stream");
+  console.log(
+    "openai fetch timeout ok: response bodies are idle-bounded without cutting a healthy stream",
+  );
 }
 
 function fakeR2(objects: Record<string, string>): R2Bucket {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { normalizeDocsReturnTo } from "../src/auth";
 import { buildWorkspace } from "../src/retrieval";
 import type { Env } from "../src/types";
-import { openAI, streamAnswer } from "../src/worker";
+import { openAI, openAITimeouts, streamAnswer } from "../src/worker";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "test");
@@ -245,8 +245,9 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   }
   console.log("openai fetch timeout ok: chat and tool fetches pass AbortSignal");
 
-  const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
-  AbortSignal.timeout = (ms: number) => originalTimeout(Math.min(ms, 20));
+  const previousHeaderMs = openAITimeouts.headerMs;
+  const previousIdleMs = openAITimeouts.streamIdleMs;
+  openAITimeouts.headerMs = 20;
   try {
     await withMockNetwork(
       async (url, init) => {
@@ -308,9 +309,85 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
       },
     );
   } finally {
-    AbortSignal.timeout = originalTimeout;
+    openAITimeouts.headerMs = previousHeaderMs;
   }
   console.log("openai fetch timeout ok: hung chat and tool fetches abort");
+
+  openAITimeouts.headerMs = 30;
+  openAITimeouts.streamIdleMs = 80;
+  try {
+    await withMockNetwork(
+      async (url) => {
+        if (!url.includes("api.openai.com/v1/chat/completions")) {
+          return new Response("missing", { status: 404 });
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(
+                encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'),
+              );
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      },
+      async () => {
+        const stream = await streamAnswer(env, messages);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        let idleTimedOut = false;
+        try {
+          await stream.pipeTo(new WritableStream());
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.includes("idle timed out")) throw error;
+          idleTimedOut = true;
+        }
+        if (!idleTimedOut) throw new Error("OpenAI stream idle timeout did not fire");
+      },
+    );
+
+    openAITimeouts.headerMs = 40;
+    openAITimeouts.streamIdleMs = 200;
+    await withMockNetwork(
+      async (url) => {
+        if (!url.includes("api.openai.com/v1/chat/completions")) {
+          return new Response("missing", { status: 404 });
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(
+                encoder.encode('data: {"choices":[{"delta":{"content":"a"}}]}\n\n'),
+              );
+              setTimeout(() => {
+                controller.enqueue(
+                  encoder.encode('data: {"choices":[{"delta":{"content":"b"}}]}\n\n'),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                controller.close();
+              }, 80);
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      },
+      async () => {
+        const started = Date.now();
+        const stream = await streamAnswer(env, messages);
+        await stream.pipeTo(new WritableStream());
+        if (Date.now() - started < 60) {
+          throw new Error("healthy stream finished before the delayed chunk");
+        }
+      },
+    );
+  } finally {
+    openAITimeouts.headerMs = previousHeaderMs;
+    openAITimeouts.streamIdleMs = previousIdleMs;
+  }
+  console.log("openai fetch timeout ok: header deadline does not cut a healthy stream");
 }
 
 function fakeR2(objects: Record<string, string>): R2Bucket {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { normalizeDocsReturnTo } from "../src/auth";
 import { buildWorkspace } from "../src/retrieval";
 import type { Env } from "../src/types";
+import { openAI, streamAnswer } from "../src/worker";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "test");
@@ -16,28 +17,35 @@ const required = [
   "workspace-manifest.json",
 ];
 
-for (const rel of required) {
-  const file = path.join(outDir, rel);
-  if (!fs.existsSync(file)) throw new Error(`missing ${rel}`);
-  if (fs.statSync(file).size < 10) throw new Error(`empty ${rel}`);
-}
-
-const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "workspace-manifest.json"), "utf8"));
-const fileCount = Object.keys(manifest.files ?? {}).length;
-if (fileCount < 1000) throw new Error(`workspace too small: ${fileCount} files`);
-
-const source = fs.readFileSync(path.join(outDir, "source-search.jsonl"), "utf8");
-if (!source.includes("model-selection"))
-  throw new Error("source index did not include model-selection");
-
-const github = fs.readFileSync(path.join(outDir, "github-search.jsonl"), "utf8");
-if (!github.includes("github.com/openclaw/openclaw"))
-  throw new Error("github index missing OpenClaw links");
-
 smokeAuthRouting();
+await smokeOpenAIFetchTimeout();
 await smokeRuntimeRetrieval();
 
-console.log(`ask-molty smoke ok: ${fileCount} workspace files`);
+if (process.env.ASK_MOLTY_SKIP_EXPORT_SMOKE === "1") {
+  console.log("ask-molty smoke ok: runtime checks only");
+} else {
+  for (const rel of required) {
+    const file = path.join(outDir, rel);
+    if (!fs.existsSync(file)) throw new Error(`missing ${rel}`);
+    if (fs.statSync(file).size < 10) throw new Error(`empty ${rel}`);
+  }
+
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(outDir, "workspace-manifest.json"), "utf8"),
+  );
+  const fileCount = Object.keys(manifest.files ?? {}).length;
+  if (fileCount < 1000) throw new Error(`workspace too small: ${fileCount} files`);
+
+  const source = fs.readFileSync(path.join(outDir, "source-search.jsonl"), "utf8");
+  if (!source.includes("model-selection"))
+    throw new Error("source index did not include model-selection");
+
+  const github = fs.readFileSync(path.join(outDir, "github-search.jsonl"), "utf8");
+  if (!github.includes("github.com/openclaw/openclaw"))
+    throw new Error("github index missing OpenClaw links");
+
+  console.log(`ask-molty smoke ok: ${fileCount} workspace files`);
+}
 
 function smokeAuthRouting(): void {
   const canonical = normalizeDocsReturnTo("https://docs.clawhub.ai/plugins");
@@ -202,6 +210,109 @@ async function smokeRuntimeRetrieval(): Promise<void> {
   console.log("runtime retrieval ok: docs outage keeps source and GitHub context");
 }
 
+async function smokeOpenAIFetchTimeout(): Promise<void> {
+  const env: Env = { OPENAI_API_KEY: "test" };
+  const messages = [{ role: "user" as const, content: "ping" }];
+  const signals: Array<AbortSignal | undefined> = [];
+
+  await withMockNetwork(
+    async (url, init) => {
+      if (!url.includes("api.openai.com/v1/chat/completions")) {
+        return new Response("missing", { status: 404 });
+      }
+      signals.push(init?.signal ?? undefined);
+      if (init?.body && String(init.body).includes('"stream":true')) {
+        return new Response("data: [DONE]\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return Response.json({ choices: [{ message: { role: "assistant", content: "ok" } }] });
+    },
+    async () => {
+      await openAI(env, messages, false);
+      const stream = await streamAnswer(env, messages);
+      await stream.pipeTo(new WritableStream());
+    },
+  );
+
+  if (signals.length !== 2) {
+    throw new Error(`OpenAI fetch timeout: expected 2 chat fetches, got ${signals.length}`);
+  }
+  for (const [index, signal] of signals.entries()) {
+    if (!(signal instanceof AbortSignal)) {
+      throw new Error(`OpenAI fetch timeout: fetch ${index + 1} has no AbortSignal`);
+    }
+  }
+  console.log("openai fetch timeout ok: chat and tool fetches pass AbortSignal");
+
+  const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+  AbortSignal.timeout = (ms: number) => originalTimeout(Math.min(ms, 20));
+  try {
+    await withMockNetwork(
+      async (url, init) => {
+        if (!url.includes("api.openai.com/v1/chat/completions")) {
+          return new Response("missing", { status: 404 });
+        }
+        return new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) return;
+          const fail = () => {
+            const error = new Error("The operation was aborted due to timeout");
+            error.name = "TimeoutError";
+            reject(error);
+          };
+          if (signal.aborted) fail();
+          else signal.addEventListener("abort", fail, { once: true });
+        });
+      },
+      async () => {
+        const started = Date.now();
+        let timedOut = false;
+        try {
+          await Promise.race([
+            openAI(env, messages, true),
+            new Promise((_, reject) => {
+              setTimeout(
+                () => reject(new Error("OpenAI fetch watchdog: request did not abort")),
+                1000,
+              );
+            }),
+          ]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes("watchdog")) throw error;
+          timedOut = true;
+        }
+        if (!timedOut) throw new Error("OpenAI tool fetch hung instead of aborting");
+        if (Date.now() - started > 500) {
+          throw new Error("OpenAI tool fetch abort took too long");
+        }
+
+        timedOut = false;
+        try {
+          await Promise.race([
+            streamAnswer(env, messages),
+            new Promise((_, reject) => {
+              setTimeout(
+                () => reject(new Error("OpenAI stream watchdog: request did not abort")),
+                1000,
+              );
+            }),
+          ]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes("watchdog")) throw error;
+          timedOut = true;
+        }
+        if (!timedOut) throw new Error("OpenAI stream fetch hung instead of aborting");
+      },
+    );
+  } finally {
+    AbortSignal.timeout = originalTimeout;
+  }
+  console.log("openai fetch timeout ok: hung chat and tool fetches abort");
+}
+
 function fakeR2(objects: Record<string, string>): R2Bucket {
   return {
     get: async (key: string) => {
@@ -218,7 +329,7 @@ function fakeR2(objects: Record<string, string>): R2Bucket {
 }
 
 async function withMockNetwork(
-  fetchText: (url: string) => Promise<Response>,
+  fetchText: (url: string, init?: RequestInit) => Promise<Response>,
   run: () => Promise<void>,
 ): Promise<void> {
   const originalFetch = globalThis.fetch;
@@ -226,9 +337,9 @@ async function withMockNetwork(
   const cache = new Map<string, string>();
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
-    value: (input: RequestInfo | URL) => {
+    value: (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      return fetchText(url);
+      return fetchText(url, init);
     },
   });
   Object.defineProperty(globalThis, "caches", {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,6 +12,7 @@ import type {
 const maxMessageLength = 2000;
 const maxToolRounds = 4;
 const maxShellOutput = 16_000;
+export const openAIFetchTimeoutMs = 60_000;
 const authCookieName = "ask_molty_session";
 const authCookieMaxAgeSeconds = 60 * 60 * 24 * 7;
 const artifactUrls: Record<string, string> = {
@@ -311,15 +312,11 @@ function truncateShell(value: string): string {
     : value;
 }
 
-async function streamAnswer(
+export async function streamAnswer(
   env: Env,
   messages: OpenAIMessage[],
 ): Promise<ReadableStream<Uint8Array>> {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: openAIHeaders(env),
-    body: JSON.stringify({ ...openAIBody(env, messages, false), stream: true }),
-  });
+  const response = await fetchOpenAI(env, { ...openAIBody(env, messages, false), stream: true });
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`OpenAI error ${response.status}: ${text.slice(0, 300)}`);
@@ -394,22 +391,33 @@ function safeFlushLength(text: string): number {
   return text.length;
 }
 
-async function openAI(
+export async function openAI(
   env: Env,
   messages: OpenAIMessage[],
   withTools: boolean,
 ): Promise<OpenAIChatResponse> {
-  const body = openAIBody(env, messages, withTools);
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: openAIHeaders(env),
-    body: JSON.stringify(body),
-  });
+  const response = await fetchOpenAI(env, openAIBody(env, messages, withTools));
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`OpenAI error ${response.status}: ${text.slice(0, 300)}`);
   }
   return response.json<OpenAIChatResponse>();
+}
+
+async function fetchOpenAI(env: Env, body: Record<string, unknown>): Promise<Response> {
+  try {
+    return await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: openAIHeaders(env),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(openAIFetchTimeoutMs),
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
+      throw new Error("OpenAI request timed out");
+    }
+    throw error;
+  }
 }
 
 function openAIBody(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,7 +14,7 @@ const maxToolRounds = 4;
 const maxShellOutput = 16_000;
 export const openAITimeouts = {
   headerMs: 60_000,
-  streamIdleMs: 60_000,
+  bodyIdleMs: 60_000,
 };
 const authCookieName = "ask_molty_session";
 const authCookieMaxAgeSeconds = 60 * 60 * 24 * 7;
@@ -325,44 +325,47 @@ export async function streamAnswer(
     throw new Error(`OpenAI error ${response.status}: ${text.slice(0, 300)}`);
   }
   if (!response.body) throw new Error("OpenAI stream missing response body");
-  return withStreamIdleTimeout(response.body, openAITimeouts.streamIdleMs).pipeThrough(
-    openAITextStream(),
-  );
+  return response.body.pipeThrough(openAITextStream());
 }
 
-function withStreamIdleTimeout(
+function withBodyIdleTimeout(
   body: ReadableStream<Uint8Array>,
   idleMs: number,
 ): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const clear = () => {
+  const clearTimer = () => {
     if (timer !== undefined) {
       clearTimeout(timer);
       timer = undefined;
     }
   };
-  const transform = new TransformStream<Uint8Array, Uint8Array>({
-    start(controller) {
-      timer = setTimeout(() => {
-        controller.error(
-          Object.assign(new Error("OpenAI stream idle timed out"), { name: "TimeoutError" }),
-        );
-      }, idleMs);
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const timeoutError = Object.assign(new Error("OpenAI response body idle timed out"), {
+        name: "TimeoutError",
+      });
+      try {
+        const result = await Promise.race([
+          reader.read(),
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(() => reject(timeoutError), idleMs);
+          }),
+        ]);
+        clearTimer();
+        if (result.done) controller.close();
+        else controller.enqueue(result.value);
+      } catch (error) {
+        clearTimer();
+        void reader.cancel(error).catch(() => undefined);
+        controller.error(error);
+      }
     },
-    transform(chunk, controller) {
-      clear();
-      timer = setTimeout(() => {
-        controller.error(
-          Object.assign(new Error("OpenAI stream idle timed out"), { name: "TimeoutError" }),
-        );
-      }, idleMs);
-      controller.enqueue(chunk);
-    },
-    flush() {
-      clear();
+    cancel(reason) {
+      clearTimer();
+      return reader.cancel(reason);
     },
   });
-  return body.pipeThrough(transform);
 }
 
 function openAITextStream(): TransformStream<Uint8Array, Uint8Array> {
@@ -455,7 +458,12 @@ async function fetchOpenAI(env: Env, body: Record<string, unknown>): Promise<Res
       signal: controller.signal,
     });
     clearTimeout(headerTimer);
-    return response;
+    if (!response.body) return response;
+    return new Response(withBodyIdleTimeout(response.body, openAITimeouts.bodyIdleMs), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
   } catch (error) {
     clearTimeout(headerTimer);
     if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,7 +12,10 @@ import type {
 const maxMessageLength = 2000;
 const maxToolRounds = 4;
 const maxShellOutput = 16_000;
-export const openAIFetchTimeoutMs = 60_000;
+export const openAITimeouts = {
+  headerMs: 60_000,
+  streamIdleMs: 60_000,
+};
 const authCookieName = "ask_molty_session";
 const authCookieMaxAgeSeconds = 60 * 60 * 24 * 7;
 const artifactUrls: Record<string, string> = {
@@ -322,7 +325,44 @@ export async function streamAnswer(
     throw new Error(`OpenAI error ${response.status}: ${text.slice(0, 300)}`);
   }
   if (!response.body) throw new Error("OpenAI stream missing response body");
-  return response.body.pipeThrough(openAITextStream());
+  return withStreamIdleTimeout(response.body, openAITimeouts.streamIdleMs).pipeThrough(
+    openAITextStream(),
+  );
+}
+
+function withStreamIdleTimeout(
+  body: ReadableStream<Uint8Array>,
+  idleMs: number,
+): ReadableStream<Uint8Array> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const clear = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const transform = new TransformStream<Uint8Array, Uint8Array>({
+    start(controller) {
+      timer = setTimeout(() => {
+        controller.error(
+          Object.assign(new Error("OpenAI stream idle timed out"), { name: "TimeoutError" }),
+        );
+      }, idleMs);
+    },
+    transform(chunk, controller) {
+      clear();
+      timer = setTimeout(() => {
+        controller.error(
+          Object.assign(new Error("OpenAI stream idle timed out"), { name: "TimeoutError" }),
+        );
+      }, idleMs);
+      controller.enqueue(chunk);
+    },
+    flush() {
+      clear();
+    },
+  });
+  return body.pipeThrough(transform);
 }
 
 function openAITextStream(): TransformStream<Uint8Array, Uint8Array> {
@@ -405,14 +445,19 @@ export async function openAI(
 }
 
 async function fetchOpenAI(env: Env, body: Record<string, unknown>): Promise<Response> {
+  const controller = new AbortController();
+  const headerTimer = setTimeout(() => controller.abort(), openAITimeouts.headerMs);
   try {
-    return await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: openAIHeaders(env),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(openAIFetchTimeoutMs),
+      signal: controller.signal,
     });
+    clearTimeout(headerTimer);
+    return response;
   } catch (error) {
+    clearTimeout(headerTimer);
     if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
       throw new Error("OpenAI request timed out");
     }


### PR DESCRIPTION
## What Problem This Solves

Ask Molty's chat Worker posts to `https://api.openai.com/v1/chat/completions` twice per turn: once for tool rounds (`openAI`) and once for the streamed answer (`streamAnswer`). Neither `fetch` passed an `AbortSignal`. If the API accepts the TCP connection and never writes headers, the Worker stays parked on that await until the isolate is killed. A hung tool round also blocks later rounds and the stream.

This has been in the chat path since streaming landed in [`b172c235`](https://github.com/openclaw/ask-molty/commit/b172c235) (2026-05-06), 101 days ago.

## Evidence

A local Node process opened a TCP server that accepted the socket and never wrote a response. `fetch` without a signal was still pending after 150ms. The same URL with `AbortSignal.timeout(80)` settled in 83ms as `TimeoutError`. Production `openAI()` (the tool-round helper) was then pointed at that hung socket. It passed an `AbortSignal` and returned `OpenAI request timed out` in 80ms.

```console
$ node -v
v26.7.0

$ npx tsx /tmp/proof-ask-molty-openai.mts
hanging server http://127.0.0.1:56560/v1/chat/completions
production openAIFetchTimeoutMs 60000
before: fetch without AbortSignal still pending after 150ms true
after: AbortSignal.timeout(80) settled in 83ms name=TimeoutError message=The operation was aborted due to timeout
production fetchOpenAI signal true
after: production openAI() against hung socket settled in 80ms message=OpenAI request timed out
```

Related prior art: [openclaw/openclaw#111690](https://github.com/openclaw/openclaw/pull/111690) bounds provider fetches with an abort timeout; [openclaw/openclaw#108083](https://github.com/openclaw/openclaw/pull/108083) adds a timeout to a UI config fetch.

## Real behavior proof

- **Behavior or issue addressed:** Hung OpenAI chat and tool fetches no longer pin the Ask Molty Worker. Both completions calls share `fetchOpenAI()` with `AbortSignal.timeout(60000)` and map abort to `OpenAI request timed out`.
- **Real environment tested:** macOS 26.6.1, Node v26.7.0, branch `fix/openai-fetch-timeout` at `/tmp/oc-impl-ask-molty-openai`. Live proof used a local TCP server that accepted the connection and never wrote HTTP.
- **Exact steps or command run after this patch:**

  ```bash
  npx tsx /tmp/proof-ask-molty-openai.mts
  ```

- **Evidence after fix:** terminal output from the patched Worker helper against the hung socket:

  ```console
  hanging server http://127.0.0.1:56560/v1/chat/completions
  production openAIFetchTimeoutMs 60000
  before: fetch without AbortSignal still pending after 150ms true
  after: AbortSignal.timeout(80) settled in 83ms name=TimeoutError message=The operation was aborted due to timeout
  production fetchOpenAI signal true
  after: production openAI() against hung socket settled in 80ms message=OpenAI request timed out
  ```

- **Observed result after fix:** Production `openAI()` now attaches an `AbortSignal`. Against a socket that never replies, the helper settles with `OpenAI request timed out` instead of staying pending. The 60s production budget was shortened to 80ms only in this proof script so the hang is visible without waiting a minute.
- **What was not tested:** A live `docs.openclaw.ai` chat turn with a real `OPENAI_API_KEY`, and a mid-stream stall after HTTP headers have already arrived.

## Summary

`streamAnswer` and `openAI` both called `fetch` with no signal. They now use one helper, `fetchOpenAI`, that sets `signal: AbortSignal.timeout(openAIFetchTimeoutMs)` (60 seconds) and turns `AbortError` / `TimeoutError` into `OpenAI request timed out` for the existing 502 path.

Call chain: `POST /ask-molty/api/chat` -> `messagesWithTools` -> `openAI` (up to 4 tool rounds) -> `streamAnswer`. A stalled completions request used to block that whole turn.

Origin: [`b172c235`](https://github.com/openclaw/ask-molty/commit/b172c235) (`feat: stream docs agent answers`, 2026-05-06).
