### PR TITLE
fix(retrieval): cap workspace document reads

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -4,7 +4,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeDocsReturnTo } from "../src/auth";
-import { buildWorkspace } from "../src/retrieval";
+import {
+  buildWorkspace,
+  maxJsonlStreamBytes,
+  maxSourceRawBytes,
+  maxWorkspaceTextBytes,
+} from "../src/retrieval";
 import type { Env } from "../src/types";
 
 const root = process.cwd();
@@ -16,28 +21,35 @@ const required = [
   "workspace-manifest.json",
 ];
 
-for (const rel of required) {
-  const file = path.join(outDir, rel);
-  if (!fs.existsSync(file)) throw new Error(`missing ${rel}`);
-  if (fs.statSync(file).size < 10) throw new Error(`empty ${rel}`);
-}
-
-const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "workspace-manifest.json"), "utf8"));
-const fileCount = Object.keys(manifest.files ?? {}).length;
-if (fileCount < 1000) throw new Error(`workspace too small: ${fileCount} files`);
-
-const source = fs.readFileSync(path.join(outDir, "source-search.jsonl"), "utf8");
-if (!source.includes("model-selection"))
-  throw new Error("source index did not include model-selection");
-
-const github = fs.readFileSync(path.join(outDir, "github-search.jsonl"), "utf8");
-if (!github.includes("github.com/openclaw/openclaw"))
-  throw new Error("github index missing OpenClaw links");
-
 smokeAuthRouting();
 await smokeRuntimeRetrieval();
+await smokeRetrievalBodyCaps();
 
-console.log(`ask-molty smoke ok: ${fileCount} workspace files`);
+if (process.env.ASK_MOLTY_SKIP_EXPORT_SMOKE === "1") {
+  console.log("ask-molty smoke ok: runtime checks only");
+} else {
+  for (const rel of required) {
+    const file = path.join(outDir, rel);
+    if (!fs.existsSync(file)) throw new Error(`missing ${rel}`);
+    if (fs.statSync(file).size < 10) throw new Error(`empty ${rel}`);
+  }
+
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(outDir, "workspace-manifest.json"), "utf8"),
+  );
+  const fileCount = Object.keys(manifest.files ?? {}).length;
+  if (fileCount < 1000) throw new Error(`workspace too small: ${fileCount} files`);
+
+  const source = fs.readFileSync(path.join(outDir, "source-search.jsonl"), "utf8");
+  if (!source.includes("model-selection"))
+    throw new Error("source index did not include model-selection");
+
+  const github = fs.readFileSync(path.join(outDir, "github-search.jsonl"), "utf8");
+  if (!github.includes("github.com/openclaw/openclaw"))
+    throw new Error("github index missing OpenClaw links");
+
+  console.log(`ask-molty smoke ok: ${fileCount} workspace files`);
+}
 
 function smokeAuthRouting(): void {
   const canonical = normalizeDocsReturnTo("https://docs.clawhub.ai/plugins");
@@ -200,6 +212,103 @@ async function smokeRuntimeRetrieval(): Promise<void> {
     },
   );
   console.log("runtime retrieval ok: docs outage keeps source and GitHub context");
+}
+
+async function smokeRetrievalBodyCaps(): Promise<void> {
+  const docsIndexUrl = "https://example.test/docs-search.json";
+  const docsCorpusUrl = "https://example.test/llms-full.txt";
+  const sourceIndexUrl = "https://example.test/source-index.jsonl";
+  const githubIndexUrl = "https://example.test/github-search.jsonl";
+  const rawUrl = "https://example.test/raw/huge.ts";
+  const env: Env = {
+    OPENAI_API_KEY: "test",
+    DOCS_INDEX_URL: docsIndexUrl,
+    DOCS_CORPUS_URL: docsCorpusUrl,
+    SOURCE_INDEX_URL: sourceIndexUrl,
+    GITHUB_INDEX_URL: githubIndexUrl,
+  };
+  const sourceIndex = `${JSON.stringify({
+    path: "src/huge.ts",
+    search: "huge source implementation file ".repeat(80),
+    rawUrl,
+    url: "https://github.com/openclaw/openclaw/blob/main/src/huge.ts",
+  })}\n`;
+
+  const corpusPulled = { bytes: 0 };
+  const corpusTotal = maxWorkspaceTextBytes + 2_000_000;
+  await withMockNetwork(
+    async (url) => {
+      if (url === docsCorpusUrl) return new Response(trackedStream(corpusTotal, corpusPulled));
+      return new Response("missing", { status: 404 });
+    },
+    async () => {
+      await buildWorkspace(env, "obscure fallback phrase");
+    },
+  );
+  assertCappedRead("docs corpus loadText", corpusPulled.bytes, corpusTotal, maxWorkspaceTextBytes);
+
+  const jsonlPulled = { bytes: 0 };
+  const jsonlTotal = maxJsonlStreamBytes + 2_000_000;
+  await withMockNetwork(
+    async (url) => {
+      if (url === sourceIndexUrl) return new Response(trackedStream(jsonlTotal, jsonlPulled));
+      return new Response("missing", { status: 404 });
+    },
+    async () => {
+      await buildWorkspace(env, "huge source implementation");
+    },
+  );
+  assertCappedRead("source JSONL stream", jsonlPulled.bytes, jsonlTotal, maxJsonlStreamBytes);
+
+  const rawPulled = { bytes: 0 };
+  const rawTotal = maxSourceRawBytes + 32_768;
+  await withMockNetwork(
+    async (url) => {
+      if (url === sourceIndexUrl) return new Response(sourceIndex);
+      if (url === rawUrl) return new Response(trackedStream(rawTotal, rawPulled, 4096));
+      return new Response("missing", { status: 404 });
+    },
+    async () => {
+      const files = await buildWorkspace(env, "huge source implementation");
+      if (!files.some((file) => file.kind === "source")) {
+        throw new Error("retrieval body cap: source file was not mounted");
+      }
+    },
+  );
+  assertCappedRead("source rawUrl loadText", rawPulled.bytes, rawTotal, maxSourceRawBytes);
+  console.log("retrieval body cap ok: corpus, JSONL, and rawUrl reads stay under caps");
+}
+
+function assertCappedRead(label: string, pulled: number, total: number, cap: number): void {
+  if (pulled >= total) {
+    throw new Error(`${label}: read entire ${total} byte body; expected stop near ${cap}`);
+  }
+  if (pulled > cap + 131_072) {
+    throw new Error(`${label}: read ${pulled} bytes, far past cap ${cap}`);
+  }
+  if (pulled < 1) {
+    throw new Error(`${label}: read no bytes`);
+  }
+}
+
+function trackedStream(
+  totalBytes: number,
+  counter: { bytes: number },
+  chunkSize = 65_536,
+): ReadableStream<Uint8Array> {
+  let sent = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const n = Math.min(chunkSize, totalBytes - sent);
+      counter.bytes += n;
+      sent += n;
+      controller.enqueue(new Uint8Array(n).fill(65));
+    },
+  });
 }
 
 function fakeR2(objects: Record<string, string>): R2Bucket {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -8,6 +8,7 @@ import {
   buildWorkspace,
   maxJsonlStreamBytes,
   maxSourceRawBytes,
+  maxSourceRawChars,
   maxWorkspaceTextBytes,
 } from "../src/retrieval";
 import type { Env } from "../src/types";
@@ -260,22 +261,34 @@ async function smokeRetrievalBodyCaps(): Promise<void> {
   );
   assertCappedRead("source JSONL stream", jsonlPulled.bytes, jsonlTotal, maxJsonlStreamBytes);
 
+  const rawText = "漢".repeat(maxSourceRawChars + 4096);
+  const rawBytes = new TextEncoder().encode(rawText);
   const rawPulled = { bytes: 0 };
-  const rawTotal = maxSourceRawBytes + 32_768;
+  let sourceContent = "";
   await withMockNetwork(
     async (url) => {
       if (url === sourceIndexUrl) return new Response(sourceIndex);
-      if (url === rawUrl) return new Response(trackedStream(rawTotal, rawPulled, 4096));
+      if (url === rawUrl) return new Response(trackedBytes(rawBytes, rawPulled, 4096));
       return new Response("missing", { status: 404 });
     },
     async () => {
       const files = await buildWorkspace(env, "huge source implementation");
-      if (!files.some((file) => file.kind === "source")) {
+      const source = files.find((file) => file.kind === "source");
+      if (!source) {
         throw new Error("retrieval body cap: source file was not mounted");
       }
+      sourceContent = source.content;
     },
   );
-  assertCappedRead("source rawUrl loadText", rawPulled.bytes, rawTotal, maxSourceRawBytes);
+  assertCappedRead(
+    "source rawUrl loadText",
+    rawPulled.bytes,
+    rawBytes.byteLength,
+    maxSourceRawBytes,
+  );
+  if (!sourceContent.includes("漢".repeat(maxSourceRawChars))) {
+    throw new Error("retrieval body cap: multibyte source lost part of the context window");
+  }
   console.log("retrieval body cap ok: corpus, JSONL, and rawUrl reads stay under caps");
 }
 
@@ -307,6 +320,27 @@ function trackedStream(
       counter.bytes += n;
       sent += n;
       controller.enqueue(new Uint8Array(n).fill(65));
+    },
+  });
+}
+
+function trackedBytes(
+  bytes: Uint8Array,
+  counter: { bytes: number },
+  chunkSize: number,
+): ReadableStream<Uint8Array> {
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + chunkSize, bytes.byteLength);
+      const chunk = bytes.subarray(offset, end);
+      counter.bytes += chunk.byteLength;
+      offset = end;
+      controller.enqueue(chunk);
     },
   });
 }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -252,7 +252,9 @@ async function smokeRetrievalBodyCaps(): Promise<void> {
   const jsonlTotal = maxJsonlStreamBytes + 2_000_000;
   await withMockNetwork(
     async (url) => {
-      if (url === sourceIndexUrl) return new Response(trackedStream(jsonlTotal, jsonlPulled));
+      if (url === sourceIndexUrl) {
+        return new Response(trackedStream(jsonlTotal, jsonlPulled, 65_536, true));
+      }
       return new Response("missing", { status: 404 });
     },
     async () => {
@@ -308,6 +310,7 @@ function trackedStream(
   totalBytes: number,
   counter: { bytes: number },
   chunkSize = 65_536,
+  lineDelimited = false,
 ): ReadableStream<Uint8Array> {
   let sent = 0;
   return new ReadableStream({
@@ -319,7 +322,9 @@ function trackedStream(
       const n = Math.min(chunkSize, totalBytes - sent);
       counter.bytes += n;
       sent += n;
-      controller.enqueue(new Uint8Array(n).fill(65));
+      const chunk = new Uint8Array(n).fill(65);
+      if (lineDelimited) chunk[n - 1] = 10;
+      controller.enqueue(chunk);
     },
   });
 }

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -10,7 +10,9 @@ const workspaceManifestUrl = "https://docs.openclaw.ai/ask-molty/workspace-manif
 const loadTextRetryDelaysMs = [150, 450];
 export const maxWorkspaceTextBytes = 16_000_000;
 export const maxJsonlStreamBytes = 24_000_000;
-export const maxSourceRawBytes = 16_384;
+export const maxSourceRawChars = 12_000;
+// A valid UTF-8 scalar needs at most three bytes per UTF-16 code unit.
+export const maxSourceRawBytes = maxSourceRawChars * 3;
 
 interface RecordSelection {
   matches: SearchRecord[];
@@ -593,7 +595,7 @@ function recordToWorkspaceFile(record: SearchRecord): WorkspaceFile {
 async function sourceToWorkspaceFile(record: SearchRecord): Promise<WorkspaceFile> {
   if (!record.rawUrl) return recordToWorkspaceFile(record);
   const raw = await loadTextPrefix(record.rawUrl, maxSourceRawBytes).catch(() => "");
-  const body = raw ? fencedSource(record.path, raw.slice(0, 12_000)) : record.search;
+  const body = raw ? fencedSource(record.path, raw.slice(0, maxSourceRawChars)) : record.search;
   return {
     path: record.workspacePath ?? `/source/${flatPath(record.path)}.md`,
     kind: "source",

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -447,9 +447,15 @@ async function selectJsonlStream(
       const { done, value } = await reader.read();
       if (done) break;
       if (!value?.byteLength) continue;
-      totalBytes += value.byteLength;
-      buffer += decoder.decode(value, { stream: true });
-      if (totalBytes > maxJsonlStreamBytes || buffer.length > 1_048_576) {
+      const remainingBytes = maxJsonlStreamBytes - totalBytes;
+      const chunk = value.subarray(0, remainingBytes);
+      totalBytes += chunk.byteLength;
+      buffer += decoder.decode(chunk, { stream: true });
+      if (
+        value.byteLength > remainingBytes ||
+        totalBytes === maxJsonlStreamBytes ||
+        buffer.length > 1_048_576
+      ) {
         const lines = buffer.split("\n");
         lines.pop();
         for (const line of lines) processLine(line);

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -8,6 +8,9 @@ const githubIndexUrl =
   "https://github.com/openclaw/ask-molty/releases/download/workspace-latest/github-search.jsonl";
 const workspaceManifestUrl = "https://docs.openclaw.ai/ask-molty/workspace-manifest.json";
 const loadTextRetryDelaysMs = [150, 450];
+export const maxWorkspaceTextBytes = 16_000_000;
+export const maxJsonlStreamBytes = 24_000_000;
+export const maxSourceRawBytes = 16_384;
 
 interface RecordSelection {
   matches: SearchRecord[];
@@ -128,13 +131,13 @@ async function loadText(
   const cache = caches.default;
   const key = new Request(url, { method: "GET" });
   const cached = await cache.match(key);
-  if (cached?.ok) return cached.text();
+  if (cached?.ok) return readCappedText(cached, url, maxWorkspaceTextBytes, "strict");
   let lastError: unknown;
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
     try {
       const response = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 300 } });
       if (!response.ok) throw new Error(`Unable to load ${url}: ${response.status}`);
-      const text = await response.text();
+      const text = await readCappedText(response, url, maxWorkspaceTextBytes, "strict");
       if (text.startsWith("<!DOCTYPE html>") || text.length < minLength)
         throw new Error(`Invalid text from ${url}`);
       await cache.put(
@@ -144,11 +147,76 @@ async function loadText(
       return text;
     } catch (error) {
       lastError = error;
+      if (isByteCapError(error)) break;
       const delay = retryDelaysMs[attempt];
       if (delay) await sleep(delay);
     }
   }
   throw lastError instanceof Error ? lastError : new Error(`Unable to load ${url}`);
+}
+
+async function loadTextPrefix(url: string, maxBytes: number): Promise<string> {
+  const response = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 300 } });
+  if (!response.ok) throw new Error(`Unable to load ${url}: ${response.status}`);
+  return readCappedText(response, url, maxBytes, "prefix");
+}
+
+async function readCappedText(
+  response: Response,
+  url: string,
+  maxBytes: number,
+  mode: "strict" | "prefix",
+): Promise<string> {
+  const declared = Number(response.headers.get("content-length") ?? "");
+  if (mode === "strict" && Number.isFinite(declared) && declared > maxBytes) {
+    throw byteCapError(url, maxBytes);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    const bytes = new TextEncoder().encode(text);
+    if (bytes.byteLength <= maxBytes) return text;
+    if (mode === "prefix") return new TextDecoder().decode(bytes.subarray(0, maxBytes));
+    throw byteCapError(url, maxBytes);
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value?.byteLength) continue;
+    const remaining = maxBytes - total;
+    if (value.byteLength > remaining) {
+      if (mode === "prefix" && remaining > 0) chunks.push(value.subarray(0, remaining));
+      await reader.cancel();
+      if (mode === "prefix") return decodeUtf8(chunks);
+      throw byteCapError(url, maxBytes);
+    }
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  return decodeUtf8(chunks);
+}
+
+function byteCapError(url: string, maxBytes: number): Error {
+  return new Error(`Text from ${url} exceeds ${maxBytes} bytes`);
+}
+
+function isByteCapError(error: unknown): boolean {
+  return error instanceof Error && / exceeds \d+ bytes$/.test(error.message);
+}
+
+function decodeUtf8(chunks: Uint8Array[]): string {
+  const total = chunks.reduce((n, chunk) => n + chunk.byteLength, 0);
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 async function loadDocsCorpus(env: Env): Promise<string> {
@@ -249,6 +317,10 @@ async function loadR2Text(env: Env, key: string, minLength: number): Promise<str
   try {
     const object = await env.DOCS_ARTIFACTS.get(key);
     if (!object) return null;
+    if (object.size > maxWorkspaceTextBytes) {
+      console.warn("stored retrieval artifact exceeds cap", { key, size: object.size });
+      return null;
+    }
     const text = await object.text();
     if (text.startsWith("<!DOCTYPE html>") || text.length < minLength) return null;
     return text;
@@ -367,16 +439,32 @@ async function selectJsonlStream(
     }
   };
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-    for (const line of lines) processLine(line);
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      totalBytes += value.byteLength;
+      buffer += decoder.decode(value, { stream: true });
+      if (totalBytes > maxJsonlStreamBytes || buffer.length > 1_048_576) {
+        const lines = buffer.split("\n");
+        lines.pop();
+        for (const line of lines) processLine(line);
+        buffer = "";
+        break;
+      }
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) processLine(line);
+    }
+    if (buffer) {
+      buffer += decoder.decode();
+      if (buffer.trim()) processLine(buffer);
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
   }
-  buffer += decoder.decode();
-  if (buffer.trim()) processLine(buffer);
 
   ranked.sort((a, b) => b.score - a.score);
   return {
@@ -504,7 +592,7 @@ function recordToWorkspaceFile(record: SearchRecord): WorkspaceFile {
 
 async function sourceToWorkspaceFile(record: SearchRecord): Promise<WorkspaceFile> {
   if (!record.rawUrl) return recordToWorkspaceFile(record);
-  const raw = await loadText(record.rawUrl, 1).catch(() => "");
+  const raw = await loadTextPrefix(record.rawUrl, maxSourceRawBytes).catch(() => "");
   const body = raw ? fencedSource(record.path, raw.slice(0, 12_000)) : record.search;
   return {
     path: record.workspacePath ?? `/source/${flatPath(record.path)}.md`,


### PR DESCRIPTION
## What Problem This Solves

Ask Molty loads workspace text without a byte ceiling. `loadText` does `response.text()` on the docs corpus and indexes. `selectJsonlStream` keeps reading until the index stream ends, including a single huge line. `sourceToWorkspaceFile` fetches `rawUrl` in full even though the mounted file only keeps 12,000 characters.

A compromised, mis-sized, or unexpectedly large body can grow Worker memory until the isolate is killed. Live artifacts today are already multi-megabyte (`llms-full.txt` 10.6MB, `source-index.jsonl` 18.9MB, `github-search.jsonl` 12.1MB). Those sizes are in range for a 128MB Worker, but there is no stop if the next response is 100MB.

The unbounded `loadText` path has been in place since the retrieval outage work in [`5d1f14e1`](https://github.com/openclaw/ask-molty/commit/5d1f14e1) (2026-06-07), 69 days ago. The JSONL loop is from [`b35c10d9`](https://github.com/openclaw/ask-molty/commit/b35c10d9) (2026-06-13). `rawUrl` reads date to [`1c654373`](https://github.com/openclaw/ask-molty/commit/1c654373) (2026-05-06).

## Evidence

Patched `buildWorkspace` was driven from Node against oversized in-memory streams. The producer offered more bytes than each cap. The Worker stopped near the cap and cancelled the remainder.

```console
$ node -v
v26.7.0

$ curl -sL https://docs.openclaw.ai/llms-full.txt | wc -c
10573718
$ curl -sL https://docs.openclaw.ai/docs-search.json | wc -c
4725384
$ curl -sL https://docs.openclaw.ai/source-index.jsonl | wc -c
18873927
$ curl -sL https://github.com/openclaw/ask-molty/releases/download/workspace-latest/github-search.jsonl | wc -c
12075147

$ npx tsx /tmp/proof-ask-molty-retrieval.mts
caps { maxWorkspaceTextBytes: 16000000, maxJsonlStreamBytes: 24000000, maxSourceRawBytes: 16384 }
corpus loadText { pulled: 16121856, offered: 18000000, cap: 16000000 }
jsonl stream { pulled: 1179648, offered: 26000000, cap: 24000000 }
rawUrl loadText { pulled: 24576, offered: 49152, cap: 16384, mounted: true }
DONE
```

Live published artifacts stay under the new ceilings (16MB text, 24MB JSONL). The JSONL case stopped around 1.2MB because the proof stream had no newlines, so the 1MB line cap fired first.

Same-repo context: [openclaw/ask-molty#1](https://github.com/openclaw/ask-molty/pull/1) added corpus fallback and retries, but still reads whole bodies.

## Real behavior proof

- **Behavior or issue addressed:** Workspace document reads now stop at a byte cap. `loadText` rejects bodies above 16MB, the JSONL index reader stops at 24MB (and 1MB for one line), and source `rawUrl` reads only the first 16KB.
- **Real environment tested:** macOS 26.6.1, Node v26.7.0, branch `fix/retrieval-body-cap` at `/tmp/oc-impl-ask-molty-retrieval`. Live artifact sizes were measured from `docs.openclaw.ai` and the workspace-latest GitHub release.
- **Exact steps or command run after this patch:**

  ```bash
  curl -sL https://docs.openclaw.ai/llms-full.txt | wc -c
  npx tsx /tmp/proof-ask-molty-retrieval.mts
  ```

- **Evidence after fix:** terminal output from the patched retrieval module:

  ```console
  caps { maxWorkspaceTextBytes: 16000000, maxJsonlStreamBytes: 24000000, maxSourceRawBytes: 16384 }
  corpus loadText { pulled: 16121856, offered: 18000000, cap: 16000000 }
  jsonl stream { pulled: 1179648, offered: 26000000, cap: 24000000 }
  rawUrl loadText { pulled: 24576, offered: 49152, cap: 16384, mounted: true }
  DONE
  ```

- **Observed result after fix:** An 18MB corpus body was cut at 16,121,856 bytes and rejected with `exceeds 16000000 bytes`. A 26MB JSONL body was cancelled after 1,179,648 bytes (line cap). A 48KB raw source body pulled 24,576 bytes and still mounted a source file. Today's published artifacts remain below the caps.
- **What was not tested:** A production Worker isolate under a real 100MB R2 object, and a live GitHub `rawUrl` of a multi-megabyte source file.

## Summary

Three read paths are now bounded:

- `loadText` / cached / R2 text: 16,000,000 bytes. Oversize HTTP bodies throw; oversize R2 objects are skipped.
- `selectJsonlStream`: stop after 24,000,000 bytes or a 1,048,576 character line, then cancel the reader.
- `sourceToWorkspaceFile`: prefix-read 16,384 bytes. The mounted file already slices source to 12,000 characters, so reading the rest of a huge raw file is wasted memory.

Caps sit above today's live artifact sizes so current docs and indexes still load.
