### PR TITLE
fix(stream): skip malformed and non-text OpenAI SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Keep streamed answers flowing past malformed JSON and non-text SSE events. Thanks @SebTardif (#10).

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -449,6 +449,15 @@ async function smokeMalformedOpenAISse(): Promise<void> {
               encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
             );
             controller.enqueue(encoder.encode("data: {not-valid-json\n\n"));
+            for (const payload of [
+              null,
+              false,
+              42,
+              "not a chunk",
+              { choices: [{ delta: { content: { text: "not text" } } }] },
+            ]) {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+            }
             controller.enqueue(
               encoder.encode('data: {"choices":[{"delta":{"content":" world"}}]}\n\n'),
             );
@@ -473,7 +482,7 @@ async function smokeMalformedOpenAISse(): Promise<void> {
       }
     },
   );
-  console.log("openai sse ok: malformed JSON events are skipped");
+  console.log("openai sse ok: malformed JSON and non-text events are skipped");
 }
 
 async function smokeRetrievalBodyCaps(): Promise<void> {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -25,6 +25,7 @@ const required = [
 
 smokeAuthRouting();
 await smokeOpenAIFetchTimeout();
+await smokeMalformedOpenAISse();
 await smokeRuntimeRetrieval();
 await smokeRetrievalBodyCaps();
 
@@ -429,6 +430,50 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   console.log(
     "openai fetch timeout ok: response bodies are idle-bounded without cutting a healthy stream",
   );
+}
+
+async function smokeMalformedOpenAISse(): Promise<void> {
+  const env: Env = { OPENAI_API_KEY: "test" };
+  const messages = [{ role: "user" as const, content: "ping" }];
+  const encoder = new TextEncoder();
+
+  await withMockNetwork(
+    async (url) => {
+      if (!url.includes("api.openai.com/v1/chat/completions")) {
+        return new Response("missing", { status: 404 });
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+            );
+            controller.enqueue(encoder.encode("data: {not-valid-json\n\n"));
+            controller.enqueue(
+              encoder.encode('data: {"choices":[{"delta":{"content":" world"}}]}\n\n'),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+    },
+    async () => {
+      const stream = await streamAnswer(env, messages);
+      let text = "";
+      try {
+        text = await new Response(stream).text();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`OpenAI SSE: malformed JSON aborted the stream: ${message}`);
+      }
+      if (text !== "Hello world") {
+        throw new Error(`OpenAI SSE: expected "Hello world", got ${JSON.stringify(text)}`);
+      }
+    },
+  );
+  console.log("openai sse ok: malformed JSON events are skipped");
 }
 
 async function smokeRetrievalBodyCaps(): Promise<void> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -395,8 +395,9 @@ function openAITextStream(): TransformStream<Uint8Array, Uint8Array> {
       } catch {
         continue;
       }
+      if (!parsed || typeof parsed !== "object") continue;
       const content = parsed.choices?.[0]?.delta?.content;
-      if (!content) continue;
+      if (typeof content !== "string" || !content) continue;
       textBuffer += content;
       flushText(controller);
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -389,7 +389,12 @@ function openAITextStream(): TransformStream<Uint8Array, Uint8Array> {
       if (!line.startsWith("data:")) continue;
       const data = line.slice(5).trim();
       if (!data || data === "[DONE]") continue;
-      const parsed = JSON.parse(data) as OpenAIStreamChunk;
+      let parsed: OpenAIStreamChunk;
+      try {
+        parsed = JSON.parse(data) as OpenAIStreamChunk;
+      } catch {
+        continue;
+      }
       const content = parsed.choices?.[0]?.delta?.content;
       if (!content) continue;
       textBuffer += content;


### PR DESCRIPTION
Malformed OpenAI SSE events could terminate an already-started Ask Molty answer. The parser now skips invalid JSON, null/primitive payloads, and non-string content, preserving valid text before and after the bad event.

The smoke regression includes invalid JSON, JSON null, primitives, and object-valued content. The changelog credits @SebTardif, whose original fix and commit remain on the branch.

Validation passed:

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `ASK_MOLTY_SKIP_EXPORT_SMOKE=1 npm run smoke`
- Codex autoreview: scoped-clean at the default P0 threshold.

Live HTTP proof used curl against the esbuild-bundled Worker through a Node 24 HTTP adapter, with real localhost upstream SSE writes and synthetic sessions/data. Main truncated both malformed-JSON and null cases after `Hello`; this branch returned `Hello world` with curl exit 0 for both. This tests the actual route/parser boundary with local faults; production OpenAI inference and Cloudflare deployment were not exercised. Full workspace-export validation runs in CI.

[Detailed before/after proof](https://github.com/openclaw/ask-molty/pull/10#issuecomment-5475256573).
