### PR TITLE
fix(ci): clear fresh CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -17,7 +20,6 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          cache: npm
           node-version: 24
 
       - name: Install sqlite

--- a/scripts/export-workspace.ts
+++ b/scripts/export-workspace.ts
@@ -445,12 +445,10 @@ function stripFrontmatter(value: string): string {
 function firstHeading(value: string): string | undefined {
   const heading = value.match(/^#\s+(.+)$/m)?.[1];
   if (!heading) return undefined;
-  // Remove complete tags for readable titles, then any residual delimiters so
-  // malformed or nested markup cannot re-form a tag after sanitization.
-  return heading
-    .replace(/<[^>]+>/g, "")
-    .replace(/[<>]/g, "")
-    .trim();
+  // Splitting removes every "<"; later segments keep only text after their
+  // first ">" when present, so assembled titles cannot re-form an HTML tag.
+  const [text, ...markup] = heading.split("<");
+  return [text, ...markup.map((part) => part.slice(part.indexOf(">") + 1))].join("").trim();
 }
 
 function titleize(value: string): string {

--- a/scripts/export-workspace.ts
+++ b/scripts/export-workspace.ts
@@ -443,9 +443,13 @@ function stripFrontmatter(value: string): string {
 }
 
 function firstHeading(value: string): string | undefined {
-  return value
-    .match(/^#\s+(.+)$/m)?.[1]
-    ?.replace(/<[^>]+>/g, "")
+  const heading = value.match(/^#\s+(.+)$/m)?.[1];
+  if (!heading) return undefined;
+  // Remove complete tags for readable titles, then any residual delimiters so
+  // malformed or nested markup cannot re-form a tag after sanitization.
+  return heading
+    .replace(/<[^>]+>/g, "")
+    .replace(/[<>]/g, "")
     .trim();
 }
 


### PR DESCRIPTION
## What Problem This Solves

GitHub default setup reported seven fresh CodeQL alerts on `main` in run 32454395463:

- five cache-poisoning alerts after the workflow checks out the OpenClaw source revision selected by the docs mirror
- one workflow with implicit `GITHUB_TOKEN` permissions
- one incomplete multi-character sanitizer in exported document headings

## Why This Change Was Made

The five workflow findings share one trust boundary: `actions/setup-node` kept a writable npm cache active while later steps processed a dynamically selected source checkout. The workflow does not need dependency caching, so this removes that cache instead of weakening the source-revision validation path. It also declares the workflow's only required token permission, `contents: read`.

The exporter no longer sanitizes headings by replacing multi-character tag matches. It splits on every opening delimiter, then keeps only visible text after each segment's first closing delimiter. That preserves normal heading text without constructing an intermediate string that can re-form a tag.

## User Impact

Ask Molty runtime behavior is unchanged. CI may spend slightly longer installing dependencies without the npm cache. Exported headings retain their visible text and cannot carry residual HTML tag delimiters.

## Evidence

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `ASK_MOLTY_SKIP_EXPORT_SMOKE=1 npm run smoke`
- `actionlint .github/workflows/ci.yml .github/workflows/clawsweeper-dispatch.yml`
- crafted export fixture: `<strong>Ask</strong> <<script Molty` exports as `Ask script Molty` with no angle delimiters
- `git diff --check`
- CI run 32455289073 passed on exact head `60359954da5fe5da012f4b4daf5545208036d348`
- CodeQL default-setup run 32455286512 passed both Actions and JavaScript/TypeScript analyses; the PR CodeQL policy check is green with zero open PR alerts
- ClawSweeper exact-head review run 32455319408 completed with no findings, security cleared, and no rank-up moves

Production delta: `scripts/export-workspace.ts` is +2 net lines for the sanitizer invariant. Workflow delta is +2 net lines.
