### PR TITLE
fix(ci): materialize source as data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,28 @@ jobs:
           path: docs-openclaw
           repository: openclaw/docs
 
-      - name: Read source revision
-        id: source
-        working-directory: docs-openclaw
+      - name: Materialize OpenClaw source snapshot
         run: |
-          echo "sha=$(node -p 'JSON.parse(require("fs").readFileSync(".openclaw-sync/source.json", "utf8")).sha')" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout OpenClaw source
-        uses: actions/checkout@v6
-        with:
-          path: clawdbot5
-          ref: ${{ steps.source.outputs.sha }}
-          repository: openclaw/openclaw
+          source_sha="$(
+            node -e '
+              const fs = require("node:fs");
+              const { sha } = JSON.parse(
+                fs.readFileSync("docs-openclaw/.openclaw-sync/source.json", "utf8"),
+              );
+              if (!/^[0-9a-f]{40}$/.test(sha)) throw new Error("invalid source revision");
+              process.stdout.write(sha);
+            '
+          )"
+          archive="$RUNNER_TEMP/openclaw-source.tar.gz"
+          curl --fail --location --retry 3 \
+            --output "$archive" \
+            "https://codeload.github.com/openclaw/openclaw/tar.gz/$source_sha"
+          mkdir clawdbot5
+          tar -xzf "$archive" --strip-components=1 -C clawdbot5
+          git -C clawdbot5 init --quiet
+          # The exporter only needs Git's tracked-file index; intent-to-add
+          # avoids duplicating the full source snapshot into Git objects.
+          git -C clawdbot5 add --intent-to-add --force --all
 
       - name: Create gitcrawl fixture
         run: |


### PR DESCRIPTION
## What Problem This Solves

Post-merge default-setup verification for #11 showed that five `actions/cache-poisoning/poisonable-step` alerts remained on squash SHA `429401a8c18a23539a6f008151d47f070fe720b5`.

The original cache removal was incomplete. CodeQL treats the dynamically selected `actions/checkout` revision itself as untrusted code in the externally triggerable `workflow_dispatch` context, regardless of whether `setup-node` caching is enabled.

## Why This Change Was Made

The OpenClaw source tree is exporter input, not executable CI code. This change preserves the docs-pinned revision and manual dispatch behavior while materializing that revision as data:

- validate the docs mirror revision as exactly 40 lowercase hexadecimal characters
- download the immutable commit archive from the fixed `openclaw/openclaw` codeload origin
- extract it into the source workspace
- create only the Git tracked-file index the exporter requires, using intent-to-add so the snapshot is not duplicated into Git objects

No dynamic source revision crosses an `actions/checkout` boundary.

## User Impact

CI still validates the exact OpenClaw revision recorded by the docs mirror on pull requests, pushes, and manual dispatches. Runtime and exported workspace behavior are unchanged.

## Evidence

- `actionlint .github/workflows/ci.yml .github/workflows/clawsweeper-dispatch.yml`
- `npm run format:check`
- live docs-pinned snapshot `750f2f37629d75599a4be7152879caa8dda16baa` downloaded and indexed successfully
- exporter produced 30,681 source records and preserved the pinned SHA in `workspace-manifest.json`
- forced intent-to-add index includes tracked files that match ignore patterns
- `git diff --check`
- exact-head CI run `32456219630`: passed
- exact-head CodeQL run `32456217770`: Actions and JavaScript/TypeScript analyses passed
- PR CodeQL policy check `96694009845`: passed; zero open PR-scoped alerts
- exact-head ClawSweeper run `32456228948`: patch correct, security cleared, no findings; its sole rank-up move was completion of the now-green CI check

Workflow delta: +10 net lines for the source-data trust boundary while preserving `workflow_dispatch` and exact-revision validation.
