### PR TITLE
fix(auth): abort OIDC token exchange fetch

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -12,7 +12,7 @@ import {
   maxWorkspaceTextBytes,
 } from "../src/retrieval";
 import type { Env } from "../src/types";
-import { openAI, openAITimeouts, streamAnswer } from "../src/worker";
+import worker, { openAI, openAITimeouts, oidcTimeouts, streamAnswer } from "../src/worker";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "test");
@@ -25,6 +25,7 @@ const required = [
 
 smokeAuthRouting();
 await smokeOpenAIFetchTimeout();
+await smokeOidcTokenFetchTimeout();
 await smokeRuntimeRetrieval();
 await smokeRetrievalBodyCaps();
 
@@ -429,6 +430,131 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   console.log(
     "openai fetch timeout ok: response bodies are idle-bounded without cutting a healthy stream",
   );
+}
+
+async function smokeOidcTokenFetchTimeout(): Promise<void> {
+  const env: Env = {
+    OPENAI_API_KEY: "test",
+    ASK_MOLTY_AUTH_SECRET: "test-oidc-secret",
+    OPENCLAW_ID_CLIENT_ID: "molty-client",
+    OPENCLAW_ID_CLIENT_SECRET: "molty-secret",
+    OPENCLAW_ID_ISSUER: "https://id.example.test/api/auth",
+  };
+  const tokenUrl = `${env.OPENCLAW_ID_ISSUER}/oauth2/token`;
+  const state = await signedOidcState("test-oidc-secret", "https://docs.openclaw.ai/install");
+  const request = new Request(
+    `https://docs.openclaw.ai/ask-molty/auth/oidc-callback?code=test-code&state=${state}`,
+  );
+
+  const signals: Array<AbortSignal | undefined> = [];
+  await withMockNetwork(
+    async (url, init) => {
+      if (url !== tokenUrl) return new Response("missing", { status: 404 });
+      signals.push(init?.signal ?? undefined);
+      return Response.json({ id_token: fakeIdToken("user@example.com") });
+    },
+    async () => {
+      const response = await worker.fetch(request, env);
+      if (response.status !== 302) {
+        throw new Error(
+          `OIDC token fetch: expected 302 after token exchange, got ${response.status}`,
+        );
+      }
+    },
+  );
+  if (signals.length !== 1) {
+    throw new Error(`OIDC token fetch: expected 1 token fetch, got ${signals.length}`);
+  }
+  if (!(signals[0] instanceof AbortSignal)) {
+    throw new Error("OIDC token fetch: token exchange has no AbortSignal");
+  }
+  console.log("oidc token fetch timeout ok: token exchange passes AbortSignal");
+
+  const previousHeaderMs = oidcTimeouts.headerMs;
+  oidcTimeouts.headerMs = 20;
+  try {
+    await withMockNetwork(
+      async (url, init) => {
+        if (url !== tokenUrl) return new Response("missing", { status: 404 });
+        return new Promise((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) return;
+          const fail = () => {
+            const error = new Error("The operation was aborted due to timeout");
+            error.name = "TimeoutError";
+            reject(error);
+          };
+          if (signal.aborted) fail();
+          else signal.addEventListener("abort", fail, { once: true });
+        });
+      },
+      async () => {
+        const started = Date.now();
+        let response: Response;
+        try {
+          response = await Promise.race([
+            worker.fetch(request, env),
+            new Promise<Response>((_, reject) => {
+              setTimeout(
+                () => reject(new Error("OIDC token fetch watchdog: request did not abort")),
+                1000,
+              );
+            }),
+          ]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes("watchdog")) throw error;
+          throw new Error(`OIDC token fetch abort escaped as ${message}`);
+        }
+        if (response.status !== 504) {
+          throw new Error(
+            `OIDC hung token fetch: expected authErrorPage 504, got ${response.status}`,
+          );
+        }
+        const body = await response.text();
+        if (!body.includes("OpenClaw ID verification timed out")) {
+          throw new Error(
+            `OIDC hung token fetch: authErrorPage missing timeout copy: ${body.slice(0, 200)}`,
+          );
+        }
+        if (Date.now() - started > 500) {
+          throw new Error("OIDC token fetch abort took too long");
+        }
+      },
+    );
+  } finally {
+    oidcTimeouts.headerMs = previousHeaderMs;
+  }
+  console.log("oidc token fetch timeout ok: hung token exchange aborts to authErrorPage");
+}
+
+async function signedOidcState(secret: string, returnTo: string): Promise<string> {
+  const encoded = base64UrlEncode(
+    JSON.stringify({ r: returnTo, exp: Math.floor(Date.now() / 1000) + 600 }),
+  );
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(encoded));
+  return `${encoded}.${base64UrlEncodeBytes(new Uint8Array(signature))}`;
+}
+
+function fakeIdToken(email: string): string {
+  return `hdr.${base64UrlEncode(JSON.stringify({ email, sub: email }))}.sig`;
+}
+
+function base64UrlEncode(value: string): string {
+  return base64UrlEncodeBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 async function smokeRetrievalBodyCaps(): Promise<void> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -16,6 +16,9 @@ export const openAITimeouts = {
   headerMs: 60_000,
   bodyIdleMs: 60_000,
 };
+export const oidcTimeouts = {
+  headerMs: 60_000,
+};
 const authCookieName = "ask_molty_session";
 const authCookieMaxAgeSeconds = 60 * 60 * 24 * 7;
 const artifactUrls: Record<string, string> = {
@@ -776,18 +779,31 @@ async function oidcCallback(request: Request, env: Env): Promise<Response> {
   if (!returnTo) return authErrorPage("Invalid sign-in response.", 400);
   if (!env.OPENCLAW_ID_CLIENT_ID || !env.OPENCLAW_ID_CLIENT_SECRET)
     return authErrorPage("Sign-in is not configured.", 500);
-  const tokenResponse = await fetch(`${oidcIssuer(env)}/oauth2/token`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(`${env.OPENCLAW_ID_CLIENT_ID}:${env.OPENCLAW_ID_CLIENT_SECRET}`)}`,
-    },
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code,
-      redirect_uri: oidcRedirectUri(request),
-    }),
-  });
+  const controller = new AbortController();
+  const headerTimer = setTimeout(() => controller.abort(), oidcTimeouts.headerMs);
+  let tokenResponse: Response;
+  try {
+    tokenResponse = await fetch(`${oidcIssuer(env)}/oauth2/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${btoa(`${env.OPENCLAW_ID_CLIENT_ID}:${env.OPENCLAW_ID_CLIENT_SECRET}`)}`,
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: oidcRedirectUri(request),
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
+      return authErrorPage("OpenClaw ID verification timed out. Please try again.", 504);
+    }
+    throw error;
+  } finally {
+    clearTimeout(headerTimer);
+  }
   if (!tokenResponse.ok) return authErrorPage("OpenClaw ID verification failed.", 401);
   const tokens = await tokenResponse.json<{ id_token?: string }>();
   // The id_token arrives directly from the issuer over TLS on an


### PR DESCRIPTION
## What Problem This Solves

`GET /ask-molty/auth/oidc-callback` posts the authorization code to `${oidcIssuer(env)}/oauth2/token` with no `AbortSignal`. If OpenClaw ID accepts the TCP connection and never writes token headers, the Worker stays parked on that `await fetch` until the isolate is killed. The user never reaches `authErrorPage`, and the isolate cannot take another sign-in on that request.

Sibling chat fetches already use a clearable header `AbortController` (`fetchOpenAI`, #8). The OIDC token exchange did not. This has been in the callback since [`5220fe94`](https://github.com/openclaw/ask-molty/commit/5220fe94) (`feat: replace ClawHub auth broker with OpenClaw ID OIDC`, 2026-08-13), 16 days ago.

## Evidence

A local Node process opened a TCP server that accepted the socket and never wrote HTTP. `fetch` without a signal was still pending after 150ms. The same URL with `AbortSignal.timeout(80)` settled in 84ms as `TimeoutError`. Production `GET /ask-molty/auth/oidc-callback` was then pointed at that hung issuer. It aborted the token exchange and returned the existing `authErrorPage` HTML with status 504.

```console
$ node -v
v26.7.0

$ date '+%Y-%m-%d %H:%M:%S %Z'
2026-08-29 11:12:28 PDT

$ npx tsx /tmp/proof-ask-molty-oidc.mts
hanging server http://127.0.0.1:63084/oauth2/token
production oidcTimeouts.headerMs 60000
before: fetch without AbortSignal still pending after 150ms true elapsed=160ms
after: AbortSignal.timeout(80) settled in 84ms name=TimeoutError message=The operation was aborted due to timeout
after: production GET /ask-molty/auth/oidc-callback against hung IdP settled in 84ms status=504
after: content-type text/html; charset=utf-8
after: title Ask Molty verification failed
after: copy OpenClaw ID verification timed out. Please try again.
```

Related prior art: [ask-molty#8](https://github.com/openclaw/ask-molty/pull/8) bounds OpenAI chat and tool fetches with a header deadline; [openclaw/openclaw#108701](https://github.com/openclaw/openclaw/pull/108701) bounds Telegram QA OIDC requests; [openclaw/openclaw#111690](https://github.com/openclaw/openclaw/pull/111690) bounds provider fetches with an abort timeout.

## Real behavior proof

- **Behavior or issue addressed:** A stalled OpenClaw ID token endpoint no longer pins the Ask Molty Worker. `oidcCallback` now attaches a header `AbortController` (60s, same budget as #8) and maps abort to `authErrorPage` with status 504.
- **Real environment tested:** macOS 26.6.2, Node v26.7.0, branch `fix/f004-oidc-token-abort` at `/tmp/oc-pr-ask-molty-F004`. Live proof used a local TCP server that accepted the connection and never wrote HTTP.
- **Exact steps or command run after this patch:**

  ```bash
  npx tsx /tmp/proof-ask-molty-oidc.mts
  ```

- **Evidence after fix:** terminal output from the patched Worker against the hung issuer:

  ```console
  hanging server http://127.0.0.1:63084/oauth2/token
  production oidcTimeouts.headerMs 60000
  before: fetch without AbortSignal still pending after 150ms true elapsed=160ms
  after: AbortSignal.timeout(80) settled in 84ms name=TimeoutError message=The operation was aborted due to timeout
  after: production GET /ask-molty/auth/oidc-callback against hung IdP settled in 84ms status=504
  after: content-type text/html; charset=utf-8
  after: title Ask Molty verification failed
  after: copy OpenClaw ID verification timed out. Please try again.
  ```

- **Observed result after fix:** Production `GET /ask-molty/auth/oidc-callback` now attaches an `AbortSignal` to the token `fetch`. Against a socket that never replies, the callback settles with the verification-failed HTML page and status 504 instead of staying pending. The 60s production budget was shortened to 80ms only in this proof script so the hang is visible without waiting a minute.
- **What was not tested:** A live `docs.openclaw.ai` sign-in against real `id.openclaw.ai` credentials, and a token response that returns headers then stalls while streaming JSON.
- **Command:** `npx tsx /tmp/proof-ask-molty-oidc.mts`
- **Observed:** Hung IdP accepted TCP and wrote nothing. Unbounded `fetch` still pending at 150ms. Patched callback settled in 84ms with status 504 and copy `OpenClaw ID verification timed out. Please try again.`
- **Expected:** Token exchange aborts after the header deadline and maps to `authErrorPage` instead of pinning the isolate.
- **Time:** 11:12:28 PDT (84ms after abort)
- **Date:** 2026-08-29
- **Environment:** macOS 26.6.2 (25G83), Node v26.7.0, `/tmp/oc-pr-ask-molty-F004` at `fix/f004-oidc-token-abort`

## Summary

`oidcCallback` called `fetch` on `/oauth2/token` with no signal. It now uses a header `AbortController` cleared after headers arrive (`oidcTimeouts.headerMs`, 60 seconds) and turns `AbortError` / `TimeoutError` into `authErrorPage(..., 504)`.

Call chain: `GET /ask-molty/auth/oidc-callback` -> `oidcCallback` -> `fetch(${issuer}/oauth2/token)`. A stalled IdP used to block that whole sign-in.

Origin: [`5220fe94`](https://github.com/openclaw/ask-molty/commit/5220fe94) (2026-08-13). Does not restack #8 (OpenAI abort), #9 (byte caps), or #10 (SSE JSON).
