### PR TITLE
fix(retrieval): abort hung corpus and index fetches

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -10,6 +10,7 @@ import {
   maxSourceRawBytes,
   maxSourceRawChars,
   maxWorkspaceTextBytes,
+  retrievalTimeouts,
 } from "../src/retrieval";
 import type { Env } from "../src/types";
 import { openAI, openAITimeouts, streamAnswer } from "../src/worker";
@@ -26,6 +27,7 @@ const required = [
 smokeAuthRouting();
 await smokeOpenAIFetchTimeout();
 await smokeRuntimeRetrieval();
+await smokeRetrievalFetchTimeout();
 await smokeRetrievalBodyCaps();
 
 if (process.env.ASK_MOLTY_SKIP_EXPORT_SMOKE === "1") {
@@ -215,6 +217,158 @@ async function smokeRuntimeRetrieval(): Promise<void> {
     },
   );
   console.log("runtime retrieval ok: docs outage keeps source and GitHub context");
+}
+
+async function smokeRetrievalFetchTimeout(): Promise<void> {
+  const docsIndexUrl = "https://example.test/docs-search.json";
+  const docsCorpusUrl = "https://example.test/llms-full.txt";
+  const sourceIndexUrl = "https://example.test/source-index.jsonl";
+  const githubIndexUrl = "https://example.test/github-search.jsonl";
+  const rawUrl = "https://example.test/raw/settings.ts";
+  const env: Env = {
+    OPENAI_API_KEY: "test",
+    DOCS_INDEX_URL: docsIndexUrl,
+    DOCS_CORPUS_URL: docsCorpusUrl,
+    SOURCE_INDEX_URL: sourceIndexUrl,
+    GITHUB_INDEX_URL: githubIndexUrl,
+  };
+  const docsIndex = JSON.stringify({
+    version: 1,
+    entries: [
+      {
+        title: "Settings",
+        url: "/settings",
+        snippet: "Settings implementation.",
+        search: "settings implementation issue ".repeat(80),
+      },
+    ],
+  });
+  const sourceIndex = `${JSON.stringify({
+    path: "src/settings.ts",
+    search: "settings implementation issue ".repeat(80),
+    rawUrl,
+    url: "https://github.com/openclaw/openclaw/blob/main/src/settings.ts",
+  })}\n`;
+  const githubIndex = `${JSON.stringify({
+    path: "/workspace/github/000.md#issue-123",
+    number: 123,
+    state: "open",
+    title: "Settings issue",
+    url: "https://github.com/openclaw/openclaw/issues/123",
+    search: "settings implementation issue ".repeat(80),
+  })}\n`;
+  const signals = new Map<string, AbortSignal | undefined>();
+
+  await withMockNetwork(
+    async (url, init) => {
+      signals.set(url, init?.signal ?? undefined);
+      if (url === docsIndexUrl) return new Response(docsIndex);
+      if (url === sourceIndexUrl) return new Response(sourceIndex);
+      if (url === githubIndexUrl) return new Response(githubIndex);
+      if (url === rawUrl) return new Response("export const settings = 1;\n");
+      return new Response("missing", { status: 404 });
+    },
+    async () => {
+      await buildWorkspace(env, "settings implementation issue");
+    },
+  );
+
+  for (const url of [docsIndexUrl, sourceIndexUrl, githubIndexUrl, rawUrl]) {
+    if (!(signals.get(url) instanceof AbortSignal)) {
+      throw new Error(`retrieval fetch timeout: ${url} has no AbortSignal`);
+    }
+  }
+  if (signals.has(docsCorpusUrl)) {
+    throw new Error("retrieval fetch timeout: docs corpus fetched despite a usable index");
+  }
+  console.log("retrieval fetch timeout ok: corpus, index, and rawUrl fetches pass AbortSignal");
+
+  const previousHeaderMs = retrievalTimeouts.headerMs;
+  retrievalTimeouts.headerMs = 20;
+  try {
+    await withMockNetwork(
+      async (_url, init) => hangUntilAborted(init),
+      async () => {
+        const started = Date.now();
+        const files = await Promise.race([
+          buildWorkspace(env, "settings implementation issue"),
+          new Promise<never>((_, reject) => {
+            setTimeout(
+              () => reject(new Error("retrieval fetch watchdog: request did not abort")),
+              1000,
+            );
+          }),
+        ]);
+        if (Date.now() - started > 500) {
+          throw new Error("retrieval fetch abort took too long");
+        }
+        if (!files.some((file) => file.path === "/workspace/docs/unavailable.md")) {
+          throw new Error("retrieval fetch timeout: hung indexes did not fail closed");
+        }
+        if (files.some((file) => file.kind === "source" || file.kind === "github")) {
+          throw new Error("retrieval fetch timeout: hung indexes still mounted source or GitHub");
+        }
+      },
+    );
+  } finally {
+    retrievalTimeouts.headerMs = previousHeaderMs;
+  }
+  console.log("retrieval fetch timeout ok: hung corpus and index fetches abort");
+
+  retrievalTimeouts.headerMs = 20;
+  try {
+    let rawHung = false;
+    await withMockNetwork(
+      async (url, init) => {
+        if (url === docsIndexUrl) return new Response(docsIndex);
+        if (url === sourceIndexUrl) return new Response(sourceIndex);
+        if (url === githubIndexUrl) return new Response(githubIndex);
+        if (url === rawUrl) {
+          rawHung = true;
+          return hangUntilAborted(init);
+        }
+        return new Response("missing", { status: 404 });
+      },
+      async () => {
+        const started = Date.now();
+        const files = await Promise.race([
+          buildWorkspace(env, "settings implementation issue"),
+          new Promise<never>((_, reject) => {
+            setTimeout(
+              () => reject(new Error("retrieval rawUrl watchdog: request did not abort")),
+              1000,
+            );
+          }),
+        ]);
+        if (!rawHung) throw new Error("retrieval fetch timeout: source rawUrl was not fetched");
+        if (Date.now() - started > 500) {
+          throw new Error("retrieval rawUrl fetch abort took too long");
+        }
+        if (!files.some((file) => file.kind === "source")) {
+          throw new Error("retrieval fetch timeout: hung rawUrl blocked source context");
+        }
+      },
+    );
+  } finally {
+    retrievalTimeouts.headerMs = previousHeaderMs;
+  }
+  console.log(
+    "retrieval fetch timeout ok: hung source rawUrl fetch aborts without blocking the mount",
+  );
+}
+
+function hangUntilAborted(init?: RequestInit): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return;
+    const fail = () => {
+      const error = new Error("The operation was aborted due to timeout");
+      error.name = "TimeoutError";
+      reject(error);
+    };
+    if (signal.aborted) fail();
+    else signal.addEventListener("abort", fail, { once: true });
+  });
 }
 
 async function smokeOpenAIFetchTimeout(): Promise<void> {

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -8,6 +8,9 @@ const githubIndexUrl =
   "https://github.com/openclaw/ask-molty/releases/download/workspace-latest/github-search.jsonl";
 const workspaceManifestUrl = "https://docs.openclaw.ai/ask-molty/workspace-manifest.json";
 const loadTextRetryDelaysMs = [150, 450];
+export const retrievalTimeouts = {
+  headerMs: 60_000,
+};
 export const maxWorkspaceTextBytes = 16_000_000;
 export const maxJsonlStreamBytes = 24_000_000;
 export const maxSourceRawChars = 12_000;
@@ -137,7 +140,7 @@ async function loadText(
   let lastError: unknown;
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
     try {
-      const response = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 300 } });
+      const response = await fetchWithHeaderTimeout(url);
       if (!response.ok) throw new Error(`Unable to load ${url}: ${response.status}`);
       const text = await readCappedText(response, url, maxWorkspaceTextBytes, "strict");
       if (text.startsWith("<!DOCTYPE html>") || text.length < minLength)
@@ -149,7 +152,7 @@ async function loadText(
       return text;
     } catch (error) {
       lastError = error;
-      if (isByteCapError(error)) break;
+      if (isByteCapError(error) || isTimeoutError(error)) break;
       const delay = retryDelaysMs[attempt];
       if (delay) await sleep(delay);
     }
@@ -158,9 +161,29 @@ async function loadText(
 }
 
 async function loadTextPrefix(url: string, maxBytes: number): Promise<string> {
-  const response = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 300 } });
+  const response = await fetchWithHeaderTimeout(url);
   if (!response.ok) throw new Error(`Unable to load ${url}: ${response.status}`);
   return readCappedText(response, url, maxBytes, "prefix");
+}
+
+async function fetchWithHeaderTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const headerTimer = setTimeout(() => controller.abort(), retrievalTimeouts.headerMs);
+  try {
+    return await fetch(url, {
+      cf: { cacheEverything: true, cacheTtl: 300 },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      const timeout = new Error(`Unable to load ${url}: timed out`);
+      timeout.name = "TimeoutError";
+      throw timeout;
+    }
+    throw error;
+  } finally {
+    clearTimeout(headerTimer);
+  }
 }
 
 async function readCappedText(
@@ -208,6 +231,10 @@ function byteCapError(url: string, maxBytes: number): Error {
 
 function isByteCapError(error: unknown): boolean {
   return error instanceof Error && / exceeds \d+ bytes$/.test(error.message);
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 function decodeUtf8(chunks: Uint8Array[]): string {
@@ -299,7 +326,7 @@ async function loadSearchSelection(
   }
 
   try {
-    const response = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 300 } });
+    const response = await fetchWithHeaderTimeout(url);
     if (!response.ok || !response.body)
       throw new Error(`Unable to load ${url}: ${response.status}`);
     const selection = await selectJsonlStream(response.body, kind, query, limit);


### PR DESCRIPTION
## What Problem This Solves

Authenticated `POST /api/chat` (and `POST /ask-molty/api/chat`) calls `buildWorkspace` before the model runs. That path fetches the docs search index, the docs corpus, the source JSONL index, the GitHub JSONL index, and selected source `rawUrl` bodies with no `AbortSignal`.

If `docs.openclaw.ai` or the GitHub release index accepts TCP and never writes headers, `loadText` never reaches its retry `sleep`, and `loadSearchSelection` never returns. The Worker stays parked on those `await fetch` calls until the isolate is killed. The user never gets the existing docs-unavailable workspace note, and the isolate cannot take another chat on that request.

Sibling OpenAI chat fetches already use a clearable header `AbortController` (`fetchOpenAI`, #8). The OIDC token exchange is the same pattern (#14). Retrieval did not. The unbounded corpus `fetch` has been in `loadText` since [`1c654373`](https://github.com/openclaw/ask-molty/commit/1c6543739919c0c284f8247fb9637f26171a729d) (`feat: build Ask Molty docs agent`, 2026-05-06), 115 days ago. Retries landed in [`5d1f14e1`](https://github.com/openclaw/ask-molty/commit/5d1f14e1c9cb3cd528caa8e11b77b42b82d97f95) without a deadline. Index fetches landed in [`b35c10d9`](https://github.com/openclaw/ask-molty/commit/b35c10d9c1c249b70fd9cd0195bc37b50d2b39b7). Source prefix fetches landed in [#9](https://github.com/openclaw/ask-molty/pull/9).

## Evidence

A local Node process opened a TCP server that accepted the socket and never wrote HTTP. `fetch` without a signal was still pending after 150ms. The same URL with `AbortSignal.timeout(80)` settled in 84ms as `TimeoutError`. Production `buildWorkspace` (the function `POST /api/chat` calls) was then pointed at that hung host for the docs index, corpus, source index, and GitHub index. It aborted those fetches and returned the existing docs-unavailable workspace file instead of staying pending.

```console
$ node -v
v26.7.0

$ date '+%Y-%m-%d %H:%M:%S %Z'
2026-08-29 11:28:59 PDT

$ npx tsx /tmp/proof-ask-molty-retrieval.mts
hanging server http://127.0.0.1:62603
production retrievalTimeouts.headerMs 60000
before: fetch without AbortSignal still pending after 150ms true elapsed=161ms
after: AbortSignal.timeout(80) settled in 84ms name=TimeoutError message=The operation was aborted due to timeout
after: production buildWorkspace against hung corpus and indexes settled in 411ms files=1
after: mounted docs:/workspace/docs/unavailable.md
after: docs unavailable true
after: source mounted false github mounted false
```

Related prior art: [ask-molty#8](https://github.com/openclaw/ask-molty/pull/8) bounds OpenAI chat and tool fetches with a header deadline; [ask-molty#14](https://github.com/openclaw/ask-molty/pull/14) bounds the OIDC token exchange; [ask-molty#9](https://github.com/openclaw/ask-molty/pull/9) caps retrieval body size but does not abort a hung first fetch; [ask-molty#1](https://github.com/openclaw/ask-molty/pull/1) adds corpus retry and catch, not a deadline; [openclaw/openclaw#111690](https://github.com/openclaw/openclaw/pull/111690) bounds provider fetches with an abort timeout.

## Real behavior proof

- **Behavior or issue addressed:** A stalled docs or GitHub index no longer pins the Ask Molty Worker during workspace load. `loadText`, `loadTextPrefix`, and `loadSearchSelection` now attach a header `AbortController` (60s, same budget as #8) and treat abort as a load failure, so `POST /api/chat` still returns the existing docs-unavailable note instead of hanging.
- **Real environment tested:** macOS 26.6.2, Node v26.7.0, branch `fix/f005-retrieval-fetch-abort` at `/tmp/oc-pr-ask-molty-F005`. Live proof used a local TCP server that accepted the connection and never wrote HTTP.
- **Exact steps or command run after this patch:**

  ```bash
  npx tsx /tmp/proof-ask-molty-retrieval.mts
  ```

- **Evidence after fix:** terminal output from production `buildWorkspace` against the hung host:

  ```console
  hanging server http://127.0.0.1:62603
  production retrievalTimeouts.headerMs 60000
  before: fetch without AbortSignal still pending after 150ms true elapsed=161ms
  after: AbortSignal.timeout(80) settled in 84ms name=TimeoutError message=The operation was aborted due to timeout
  after: production buildWorkspace against hung corpus and indexes settled in 411ms files=1
  after: mounted docs:/workspace/docs/unavailable.md
  after: docs unavailable true
  after: source mounted false github mounted false
  ```

- **Observed result after fix:** Production `buildWorkspace` now attaches an `AbortSignal` to corpus, index, and source `rawUrl` fetches. Against a socket that never replies, workspace load settled in 411ms with `/workspace/docs/unavailable.md` and no source or GitHub files. The 60s production budget was shortened to 80ms only in this proof script so the hang is visible without waiting a minute.
- **What was not tested:** A live authenticated `POST /api/chat` against real `docs.openclaw.ai` credentials, and a response that returns headers then stalls while streaming the body.
- **Command:** `npx tsx /tmp/proof-ask-molty-retrieval.mts`
- **Observed:** Hung index host accepted TCP and wrote nothing. Unbounded `fetch` still pending at 150ms. Patched `buildWorkspace` settled in 411ms with the docs-unavailable workspace file.
- **Expected:** Corpus and index fetches abort after the header deadline and map to the existing load-failure path instead of pinning the isolate.
- **Time:** 11:28:59 PDT (411ms after abort across the sequential fallback URLs)
- **Date:** 2026-08-29
- **Environment:** macOS 26.6.2 (25G83), Node v26.7.0, `/tmp/oc-pr-ask-molty-F005` at `fix/f005-retrieval-fetch-abort`

## Summary

`loadText`, `loadTextPrefix`, and `loadSearchSelection` called `fetch` with no signal. They now share `fetchWithHeaderTimeout`, which uses a header `AbortController` cleared after headers arrive (`retrievalTimeouts.headerMs`, 60 seconds) and turns `AbortError` / `TimeoutError` into a timed-out load failure. A timeout does not retry the same hung URL; the existing next-URL fallbacks still run.

Call chain: authenticated `POST /api/chat` -> `buildWorkspace` -> `loadDocsRecords` / `loadSearchSelection` / `sourceToWorkspaceFile` -> `fetch`. A stalled docs host used to block that whole chat.

Origin: [`1c654373`](https://github.com/openclaw/ask-molty/commit/1c6543739919c0c284f8247fb9637f26171a729d) (2026-05-06). Does not restack #8 (OpenAI abort), #9 (byte caps), or #14 (OIDC abort).
