### PR TITLE
fix(auth): handle invalid OIDC token responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Show the verification error page for malformed OIDC token JSON, null payloads, and non-string tokens. Thanks @SebTardif (#16).

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -450,6 +450,10 @@ async function smokeOidcTokenJsonParse(): Promise<void> {
   const cases: Array<{ label: string; body: string; contentType: string }> = [
     { label: "HTML", body: "<!doctype html><title>OpenClaw ID</title>", contentType: "text/html" },
     { label: "empty", body: "", contentType: "application/json" },
+    { label: "null", body: "null", contentType: "application/json" },
+    { label: "primitive", body: "42", contentType: "application/json" },
+    { label: "missing id_token", body: "{}", contentType: "application/json" },
+    { label: "non-string id_token", body: '{"id_token":42}', contentType: "application/json" },
   ];
 
   for (const tokenCase of cases) {
@@ -494,7 +498,7 @@ async function smokeOidcTokenJsonParse(): Promise<void> {
       },
     );
   }
-  console.log("oidc token json parse ok: HTML and empty token bodies return authErrorPage");
+  console.log("oidc token json parse ok: invalid JSON and token shapes return authErrorPage");
 }
 
 async function signedOidcState(secret: string, returnTo: string): Promise<string> {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -12,7 +12,7 @@ import {
   maxWorkspaceTextBytes,
 } from "../src/retrieval";
 import type { Env } from "../src/types";
-import { openAI, openAITimeouts, streamAnswer } from "../src/worker";
+import worker, { openAI, openAITimeouts, streamAnswer } from "../src/worker";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "test");
@@ -25,6 +25,7 @@ const required = [
 
 smokeAuthRouting();
 await smokeOpenAIFetchTimeout();
+await smokeOidcTokenJsonParse();
 await smokeRuntimeRetrieval();
 await smokeRetrievalBodyCaps();
 
@@ -429,6 +430,96 @@ async function smokeOpenAIFetchTimeout(): Promise<void> {
   console.log(
     "openai fetch timeout ok: response bodies are idle-bounded without cutting a healthy stream",
   );
+}
+
+async function smokeOidcTokenJsonParse(): Promise<void> {
+  const env: Env = {
+    OPENAI_API_KEY: "test",
+    ASK_MOLTY_AUTH_SECRET: "test-oidc-secret",
+    OPENCLAW_ID_CLIENT_ID: "molty-client",
+    OPENCLAW_ID_CLIENT_SECRET: "molty-secret",
+    OPENCLAW_ID_ISSUER: "https://id.example.test/api/auth",
+  };
+  const tokenUrl = `${env.OPENCLAW_ID_ISSUER}/oauth2/token`;
+  const state = await signedOidcState("test-oidc-secret", "https://docs.openclaw.ai/install");
+  const request = () =>
+    new Request(
+      `https://docs.openclaw.ai/ask-molty/auth/oidc-callback?code=test-code&state=${state}`,
+    );
+
+  const cases: Array<{ label: string; body: string; contentType: string }> = [
+    { label: "HTML", body: "<!doctype html><title>OpenClaw ID</title>", contentType: "text/html" },
+    { label: "empty", body: "", contentType: "application/json" },
+  ];
+
+  for (const tokenCase of cases) {
+    await withMockNetwork(
+      async (url) => {
+        if (url !== tokenUrl) return new Response("missing", { status: 404 });
+        return new Response(tokenCase.body, {
+          status: 200,
+          headers: { "Content-Type": tokenCase.contentType },
+        });
+      },
+      async () => {
+        let response: Response;
+        try {
+          response = await worker.fetch(request(), env);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`OIDC ${tokenCase.label} token body escaped as ${message}`);
+        }
+        if (response.status !== 401) {
+          throw new Error(
+            `OIDC ${tokenCase.label} token body: expected authErrorPage 401, got ${response.status}`,
+          );
+        }
+        const contentType = response.headers.get("content-type") ?? "";
+        if (!contentType.includes("text/html")) {
+          throw new Error(
+            `OIDC ${tokenCase.label} token body: expected HTML authErrorPage, got ${contentType}`,
+          );
+        }
+        const body = await response.text();
+        if (!body.includes("OpenClaw ID verification failed")) {
+          throw new Error(
+            `OIDC ${tokenCase.label} token body: authErrorPage missing copy: ${body.slice(0, 200)}`,
+          );
+        }
+        if (!body.includes("<title>Ask Molty verification failed</title>")) {
+          throw new Error(
+            `OIDC ${tokenCase.label} token body: missing authErrorPage title: ${body.slice(0, 200)}`,
+          );
+        }
+      },
+    );
+  }
+  console.log("oidc token json parse ok: HTML and empty token bodies return authErrorPage");
+}
+
+async function signedOidcState(secret: string, returnTo: string): Promise<string> {
+  const encoded = base64UrlEncode(
+    JSON.stringify({ r: returnTo, exp: Math.floor(Date.now() / 1000) + 600 }),
+  );
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(encoded));
+  return `${encoded}.${base64UrlEncodeBytes(new Uint8Array(signature))}`;
+}
+
+function base64UrlEncode(value: string): string {
+  return base64UrlEncodeBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 async function smokeRetrievalBodyCaps(): Promise<void> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -789,7 +789,12 @@ async function oidcCallback(request: Request, env: Env): Promise<Response> {
     }),
   });
   if (!tokenResponse.ok) return authErrorPage("OpenClaw ID verification failed.", 401);
-  const tokens = await tokenResponse.json<{ id_token?: string }>();
+  let tokens: { id_token?: string };
+  try {
+    tokens = await tokenResponse.json<{ id_token?: string }>();
+  } catch {
+    return authErrorPage("OpenClaw ID verification failed.", 401);
+  }
   // The id_token arrives directly from the issuer over TLS on an
   // authenticated confidential-client exchange, so decoding without local
   // signature verification is sufficient here.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -789,16 +789,18 @@ async function oidcCallback(request: Request, env: Env): Promise<Response> {
     }),
   });
   if (!tokenResponse.ok) return authErrorPage("OpenClaw ID verification failed.", 401);
-  let tokens: { id_token?: string };
+  let tokens: unknown;
   try {
-    tokens = await tokenResponse.json<{ id_token?: string }>();
+    tokens = await tokenResponse.json();
   } catch {
     return authErrorPage("OpenClaw ID verification failed.", 401);
   }
   // The id_token arrives directly from the issuer over TLS on an
   // authenticated confidential-client exchange, so decoding without local
   // signature verification is sufficient here.
-  const claims = decodeJwtClaims(tokens.id_token ?? "");
+  const idToken =
+    tokens && typeof tokens === "object" && "id_token" in tokens ? tokens.id_token : undefined;
+  const claims = decodeJwtClaims(typeof idToken === "string" ? idToken : "");
   const email = typeof claims?.email === "string" ? claims.email : "";
   const subject = email || (typeof claims?.sub === "string" ? claims.sub : "");
   if (!subject) return authErrorPage("OpenClaw ID verification failed.", 401);


### PR DESCRIPTION
A successful OIDC token HTTP response containing empty/HTML JSON, JSON null, or a non-string `id_token` could escape the callback as an uncaught error. The callback now catches JSON parse failures and validates the token field before decoding it, returning the existing 401 verification page for invalid responses. Successful exchanges still create a session and redirect with HTTP 302.

Callback-level smoke coverage includes HTML, empty, null, primitive, missing-token, and non-string-token responses. The changelog credits @SebTardif, whose original fix and commit remain on the branch.

Validation passed:

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `ASK_MOLTY_SKIP_EXPORT_SMOKE=1 npm run smoke`
- Codex autoreview: scoped-clean at the default P0 threshold.

Live HTTP proof used curl against the esbuild-bundled Worker through a Node 24.20.0 HTTP adapter and a real localhost token endpoint with synthetic credentials/state. All six invalid-response cases returned 401; a successful exchange returned 302. The new null regression failed before the repair. No production identity-provider sign-in or Cloudflare deployment was exercised. Full workspace-export validation runs in CI.

[Detailed before/after proof and landing integration notes](https://github.com/openclaw/ask-molty/pull/16#issuecomment-5475326515).
