### PR TITLE
fix: abort hung artifact proxy fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound stalled public artifact proxy fetches and return a retryable timeout. Thanks @SebTardif.
 - Recover from stalled docs, source, and GitHub retrieval requests instead of leaving chats pending. Thanks @SebTardif (#15).
 - Keep streamed answers flowing past malformed JSON and non-text SSE events. Thanks @SebTardif (#10).
 - Bound stalled OpenClaw ID token exchanges and show a retryable verification timeout. Thanks @SebTardif (#14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bound stalled public artifact proxy fetches and return a retryable timeout. Thanks @SebTardif.
+- Bound stalled public artifact proxy fetches and return a retryable timeout. Thanks @SebTardif (#18).
 - Recover from stalled docs, source, and GitHub retrieval requests instead of leaving chats pending. Thanks @SebTardif (#15).
 - Keep streamed answers flowing past malformed JSON and non-text SSE events. Thanks @SebTardif (#10).
 - Bound stalled OpenClaw ID token exchanges and show a retryable verification timeout. Thanks @SebTardif (#14).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ npm run export
 
 The generated workspace can be large because GitHub threads are sharded into markdown files. The Worker never downloads all of it per request; it loads small JSONL indexes, selects candidates, and only mounts the best matching docs/source/GitHub files.
 
+The public `/ask-molty/github-search.jsonl` proxy gives uncached upstream requests
+60 seconds to return headers. A header timeout returns HTTP 504 with public CORS
+headers so browser clients can read the failure and retry. The deadline ends when
+headers arrive; it does not limit the artifact body's download time.
+
 ## Deploy
 
 The Worker expects `OPENAI_API_KEY` as a Cloudflare Worker secret. The default model is `chat-latest`, which OpenAI maps to GPT-5.5 Instant in the API.

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -2,6 +2,7 @@
 /// <reference types="@cloudflare/workers-types" />
 
 import fs from "node:fs";
+import assert from "node:assert/strict";
 import path from "node:path";
 import { normalizeDocsReturnTo } from "../src/auth";
 import {
@@ -800,33 +801,77 @@ async function smokeArtifactFetchTimeout(): Promise<void> {
         return hangUntilAborted(init);
       },
       async () => {
-        const started = Date.now();
-        let response: Response;
-        try {
-          response = await Promise.race([
-            worker.fetch(request, env),
-            new Promise<Response>((_, reject) => {
-              setTimeout(
-                () => reject(new Error("artifact fetch watchdog: request did not abort")),
-                1000,
-              );
-            }),
-          ]);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          if (message.includes("watchdog")) throw error;
-          throw new Error(`artifact fetch abort escaped as ${message}`);
+        for (const method of ["GET", "HEAD"]) {
+          const started = Date.now();
+          let response: Response;
+          let watchdog: ReturnType<typeof setTimeout> | undefined;
+          try {
+            response = await Promise.race([
+              worker.fetch(new Request(request, { method }), env),
+              new Promise<Response>((_, reject) => {
+                watchdog = setTimeout(
+                  () => reject(new Error("artifact fetch watchdog: request did not abort")),
+                  1000,
+                );
+              }),
+            ]);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (message.includes("watchdog")) throw error;
+            throw new Error(`artifact fetch abort escaped as ${message}`);
+          } finally {
+            clearTimeout(watchdog);
+          }
+          if (response.status !== 504) {
+            throw new Error(`hung artifact fetch: expected 504, got ${response.status}`);
+          }
+          assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+          const body = await response.text();
+          if (method === "HEAD" ? body !== "" : !body.includes("timed out")) {
+            throw new Error(`hung artifact fetch: missing timeout copy: ${body.slice(0, 200)}`);
+          }
+          if (Date.now() - started > 500) {
+            throw new Error("artifact fetch abort took too long");
+          }
         }
-        if (response.status !== 504) {
-          throw new Error(`hung artifact fetch: expected 504, got ${response.status}`);
-        }
-        const body = await response.text();
-        if (!body.includes("timed out")) {
-          throw new Error(`hung artifact fetch: missing timeout copy: ${body.slice(0, 200)}`);
-        }
-        if (Date.now() - started > 500) {
-          throw new Error("artifact fetch abort took too long");
-        }
+      },
+    );
+
+    let slowBodySignal: AbortSignal | null | undefined;
+    await withMockNetwork(
+      async (_, init) => {
+        slowBodySignal = init?.signal;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              setTimeout(() => {
+                controller.enqueue(new TextEncoder().encode('{"slow":true}\n'));
+                controller.close();
+              }, 60);
+            },
+          }),
+        );
+      },
+      async () => {
+        const response = await worker.fetch(request, env);
+        assert.equal(await response.text(), '{"slow":true}\n');
+        assert.ok(slowBodySignal);
+        assert.equal(slowBodySignal.aborted, false, "header timer aborted a healthy body");
+      },
+    );
+
+    let failedSignal: AbortSignal | null | undefined;
+    const failure = new TypeError("artifact network failure");
+    await withMockNetwork(
+      async (_, init) => {
+        failedSignal = init?.signal;
+        throw failure;
+      },
+      async () => {
+        await assert.rejects(worker.fetch(request, env), (error) => error === failure);
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        assert.ok(failedSignal);
+        assert.equal(failedSignal.aborted, false, "header timer leaked after fetch failure");
       },
     );
   } finally {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -13,7 +13,14 @@ import {
   retrievalTimeouts,
 } from "../src/retrieval";
 import type { Env } from "../src/types";
-import worker, { openAI, openAITimeouts, oidcTimeouts, streamAnswer } from "../src/worker";
+import worker, {
+  artifactTimeouts,
+  artifactUrls,
+  openAI,
+  openAITimeouts,
+  oidcTimeouts,
+  streamAnswer,
+} from "../src/worker";
 
 const root = process.cwd();
 const outDir = path.join(root, "dist", "test");
@@ -28,6 +35,7 @@ smokeAuthRouting();
 await smokeOpenAIFetchTimeout();
 await smokeOidcTokenJsonParse();
 await smokeOidcTokenFetchTimeout();
+await smokeArtifactFetchTimeout();
 await smokeMalformedOpenAISse();
 await smokeRuntimeRetrieval();
 await smokeRetrievalFetchTimeout();
@@ -751,6 +759,80 @@ async function smokeOidcTokenFetchTimeout(): Promise<void> {
     oidcTimeouts.headerMs = previousHeaderMs;
   }
   console.log("oidc token fetch timeout ok: hung token exchange aborts to authErrorPage");
+}
+
+async function smokeArtifactFetchTimeout(): Promise<void> {
+  const env: Env = { OPENAI_API_KEY: "test" };
+  const artifactPath = "/ask-molty/github-search.jsonl";
+  const artifactUrl = artifactUrls[artifactPath] ?? "";
+  const request = new Request(`https://docs.openclaw.ai${artifactPath}`);
+
+  const signals: Array<AbortSignal | undefined> = [];
+  await withMockNetwork(
+    async (url, init) => {
+      if (url !== artifactUrl) return new Response("missing", { status: 404 });
+      signals.push(init?.signal ?? undefined);
+      return new Response('{"ok":true}\n', {
+        headers: { "Content-Type": "application/x-ndjson" },
+      });
+    },
+    async () => {
+      const response = await worker.fetch(request, env);
+      if (response.status !== 200) {
+        throw new Error(`artifact fetch: expected 200, got ${response.status}`);
+      }
+    },
+  );
+  if (signals.length !== 1) {
+    throw new Error(`artifact fetch: expected 1 upstream fetch, got ${signals.length}`);
+  }
+  if (!(signals[0] instanceof AbortSignal)) {
+    throw new Error("artifact fetch: upstream fetch has no AbortSignal");
+  }
+  console.log("artifact fetch timeout ok: proxy fetch passes AbortSignal");
+
+  const previousHeaderMs = artifactTimeouts.headerMs;
+  artifactTimeouts.headerMs = 20;
+  try {
+    await withMockNetwork(
+      async (url, init) => {
+        if (url !== artifactUrl) return new Response("missing", { status: 404 });
+        return hangUntilAborted(init);
+      },
+      async () => {
+        const started = Date.now();
+        let response: Response;
+        try {
+          response = await Promise.race([
+            worker.fetch(request, env),
+            new Promise<Response>((_, reject) => {
+              setTimeout(
+                () => reject(new Error("artifact fetch watchdog: request did not abort")),
+                1000,
+              );
+            }),
+          ]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes("watchdog")) throw error;
+          throw new Error(`artifact fetch abort escaped as ${message}`);
+        }
+        if (response.status !== 504) {
+          throw new Error(`hung artifact fetch: expected 504, got ${response.status}`);
+        }
+        const body = await response.text();
+        if (!body.includes("timed out")) {
+          throw new Error(`hung artifact fetch: missing timeout copy: ${body.slice(0, 200)}`);
+        }
+        if (Date.now() - started > 500) {
+          throw new Error("artifact fetch abort took too long");
+        }
+      },
+    );
+  } finally {
+    artifactTimeouts.headerMs = previousHeaderMs;
+  }
+  console.log("artifact fetch timeout ok: hung proxy fetch aborts to 504");
 }
 
 async function signedOidcState(secret: string, returnTo: string): Promise<string> {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -101,7 +101,10 @@ async function serveArtifact(request: Request, url: string): Promise<Response> {
     });
   } catch (error) {
     if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
-      return new Response("Artifact unavailable: timed out", { status: 504 });
+      return new Response(request.method === "HEAD" ? null : "Artifact unavailable: timed out", {
+        status: 504,
+        headers: { "Access-Control-Allow-Origin": "*" },
+      });
     }
     throw error;
   } finally {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,9 +19,12 @@ export const openAITimeouts = {
 export const oidcTimeouts = {
   headerMs: 60_000,
 };
+export const artifactTimeouts = {
+  headerMs: 60_000,
+};
 const authCookieName = "ask_molty_session";
 const authCookieMaxAgeSeconds = 60 * 60 * 24 * 7;
-const artifactUrls: Record<string, string> = {
+export const artifactUrls: Record<string, string> = {
   "/ask-molty/github-search.jsonl":
     "https://github.com/openclaw/ask-molty/releases/download/workspace-latest/github-search.jsonl",
 };
@@ -88,7 +91,22 @@ async function serveArtifact(request: Request, url: string): Promise<Response> {
   const cached = await cache.match(cacheKey);
   if (cached) return request.method === "HEAD" ? new Response(null, cached) : cached;
 
-  const upstream = await fetch(url, { cf: { cacheEverything: true, cacheTtl: 3600 } });
+  const controller = new AbortController();
+  const headerTimer = setTimeout(() => controller.abort(), artifactTimeouts.headerMs);
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      cf: { cacheEverything: true, cacheTtl: 3600 },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
+      return new Response("Artifact unavailable: timed out", { status: 504 });
+    }
+    throw error;
+  } finally {
+    clearTimeout(headerTimer);
+  }
   if (!upstream.ok)
     return new Response(`Artifact unavailable: ${upstream.status}`, { status: 502 });
   const headers = new Headers(upstream.headers);


### PR DESCRIPTION
Uncached `GET` and `HEAD /ask-molty/github-search.jsonl` requests could wait indefinitely when the upstream release host accepted the connection but never returned headers. Add a clearable 60-second header deadline and return HTTP 504 on abort. Timeout responses include public CORS headers, and HEAD responses have no body.

Clear the timer when headers arrive or fetch fails. Healthy artifact bodies may take longer than the header deadline, and existing successful cache behavior is preserved. README documents this boundary. This does not add a body-download timeout.

Validation: `npm run check` passed, including an export of 27,803 workspace files and runtime smoke coverage. The CORS regression failed on the original PR head and passed after repair. Added coverage checks GET/HEAD timeouts, healthy slow bodies, and timer cleanup after network failure. A bundled Worker running in local workerd against a real loopback HTTP server returned the expected 504/CORS responses, closed both hung upstream requests, completed a slow body, and served cached GET/HEAD without another upstream fetch. The local proof shortened the header deadline to 120 ms; production remains 60 seconds. No deployment was performed.

Original fix and reproduction by @SebTardif; maintainer follow-up preserves CORS and HEAD semantics and expands regression coverage.

CI passed on final head `28520a013c4acb72fcd7d1a2ead8dd3b6d0ab7b5`: https://github.com/openclaw/ask-molty/actions/runs/33850842060/attempts/2. The first attempt failed before tests because GitHub's source-archive endpoint returned HTTP 429; the failed-job retry passed without a code change. Isolated review found no actionable findings through P2. The same real workerd timeout, abort-cleanup, slow-body, and cache proof also passed with the dependency updates in #19.
