### PR TITLE
fix(stream): keep answers flowing on malformed GitHub blob percents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep streamed answers flowing when a GitHub blob path has a truncated or invalid percent sequence. Thanks @SebTardif.
 - Bound stalled public artifact proxy fetches and return a retryable timeout. Thanks @SebTardif (#18).
 - Recover from stalled docs, source, and GitHub retrieval requests instead of leaving chats pending. Thanks @SebTardif (#15).
 - Keep streamed answers flowing past malformed JSON and non-text SSE events. Thanks @SebTardif (#10).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Keep streamed answers flowing when a GitHub blob path has a truncated or invalid percent sequence. Thanks @SebTardif.
 - Bound stalled public artifact proxy fetches and return a retryable timeout. Thanks @SebTardif (#18).
 - Recover from stalled docs, source, and GitHub retrieval requests instead of leaving chats pending. Thanks @SebTardif (#15).
 - Keep streamed answers flowing past malformed JSON and non-text SSE events. Thanks @SebTardif (#10).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The Worker does deterministic candidate retrieval, mounts the best docs/source/G
 
 Docs are canonical. Source is implementation truth. GitHub issues/PRs are discussion and status evidence.
 
+Streamed answers compact GitHub citations into readable links. If a source path has
+malformed percent encoding, its label keeps the raw path and the answer continues.
+
 `run_shell` is deliberately fake and read-only. It supports `rg`, `grep`, `cat`, `head`, `ls`, and `find` over mounted files only. No pipes, redirects, writes, network, or process execution.
 
 ## Local Build

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -38,6 +38,7 @@ await smokeOidcTokenJsonParse();
 await smokeOidcTokenFetchTimeout();
 await smokeArtifactFetchTimeout();
 await smokeMalformedOpenAISse();
+await smokeMalformedGithubBlobPercent();
 await smokeRuntimeRetrieval();
 await smokeRetrievalFetchTimeout();
 await smokeRetrievalBodyCaps();
@@ -960,6 +961,64 @@ async function smokeMalformedOpenAISse(): Promise<void> {
     },
   );
   console.log("openai sse ok: malformed JSON and non-text events are skipped");
+}
+
+async function smokeMalformedGithubBlobPercent(): Promise<void> {
+  const env: Env = { OPENAI_API_KEY: "test" };
+  const messages = [{ role: "user" as const, content: "ping" }];
+  const encoder = new TextEncoder();
+  const truncated = "https://github.com/openclaw/openclaw/blob/abc1234/src/foo%";
+  const invalidHex = "https://github.com/openclaw/openclaw/blob/abc1234/src/%ZZ";
+  const encoded = "https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts";
+
+  await withMockNetwork(
+    async (url) => {
+      if (!url.includes("api.openai.com/v1/chat/completions")) {
+        return new Response("missing", { status: 404 });
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode('data: {"choices":[{"delta":{"content":"Hello "}}]}\n\n'),
+            );
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({
+                  choices: [{ delta: { content: `${truncated} ${invalidHex} ${encoded} done` } }],
+                })}\n\n`,
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "Content-Type": "text/event-stream" } },
+      );
+    },
+    async () => {
+      const stream = await streamAnswer(env, messages);
+      let text = "";
+      try {
+        text = await new Response(stream).text();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`github blob compact: malformed percent aborted the stream: ${message}`);
+      }
+      const expected =
+        "Hello [src/foo%](https://github.com/openclaw/openclaw/blob/abc1234/src/foo%) " +
+        "[src/%ZZ](https://github.com/openclaw/openclaw/blob/abc1234/src/%ZZ) " +
+        "[src/foo bar.ts](https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts) done";
+      if (text !== expected) {
+        throw new Error(
+          `github blob compact: expected ${JSON.stringify(expected)}, got ${JSON.stringify(text)}`,
+        );
+      }
+    },
+  );
+  console.log(
+    "github blob compact ok: truncated percent sequences keep the raw path and finish the stream",
+  );
 }
 
 async function smokeRetrievalBodyCaps(): Promise<void> {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -969,7 +969,8 @@ async function smokeMalformedGithubBlobPercent(): Promise<void> {
   const encoder = new TextEncoder();
   const truncated = "https://github.com/openclaw/openclaw/blob/abc1234/src/foo%";
   const invalidHex = "https://github.com/openclaw/openclaw/blob/abc1234/src/%ZZ";
-  const encoded = "https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts";
+  const invalidUtf8 = "https://github.com/openclaw/openclaw/blob/abc1234/src/%E0%A4#L2-L4";
+  const encoded = "https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts#L3";
 
   await withMockNetwork(
     async (url) => {
@@ -985,7 +986,13 @@ async function smokeMalformedGithubBlobPercent(): Promise<void> {
             controller.enqueue(
               encoder.encode(
                 `data: ${JSON.stringify({
-                  choices: [{ delta: { content: `${truncated} ${invalidHex} ${encoded} done` } }],
+                  choices: [
+                    {
+                      delta: {
+                        content: `${truncated} ${invalidHex} ${invalidUtf8} ${encoded} done`,
+                      },
+                    },
+                  ],
                 })}\n\n`,
               ),
             );
@@ -1008,7 +1015,8 @@ async function smokeMalformedGithubBlobPercent(): Promise<void> {
       const expected =
         "Hello [src/foo%](https://github.com/openclaw/openclaw/blob/abc1234/src/foo%) " +
         "[src/%ZZ](https://github.com/openclaw/openclaw/blob/abc1234/src/%ZZ) " +
-        "[src/foo bar.ts](https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts) done";
+        "[src/%E0%A4:L2-L4](https://github.com/openclaw/openclaw/blob/abc1234/src/%E0%A4#L2-L4) " +
+        "[src/foo bar.ts:L3](https://github.com/openclaw/openclaw/blob/abc1234/src/foo%20bar.ts#L3) done";
       if (text !== expected) {
         throw new Error(
           `github blob compact: expected ${JSON.stringify(expected)}, got ${JSON.stringify(text)}`,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -224,9 +224,14 @@ function compactGithubLinks(text: string): string {
       (_match, prefix: string, sha: string, path: string) => {
         const cleanPath = trimTrailingPunctuation(path);
         const suffix = path.slice(cleanPath.length);
-        const label = decodeURIComponent(cleanPath).replace(
-          /#L(\d+)(?:-L(\d+))?$/,
-          (_line, from, to) => (to ? `:L${from}-L${to}` : `:L${from}`),
+        let label = cleanPath;
+        try {
+          label = decodeURIComponent(cleanPath);
+        } catch (error) {
+          if (!(error instanceof URIError)) throw error;
+        }
+        label = label.replace(/#L(\d+)(?:-L(\d+))?$/, (_line, from, to) =>
+          to ? `:L${from}-L${to}` : `:L${from}`,
         );
         return `${prefix}[${label}](https://github.com/openclaw/openclaw/blob/${sha}/${cleanPath})${suffix}`;
       },


### PR DESCRIPTION
A model-generated GitHub source URL with malformed percent encoding can throw `URIError` while formatting its label, truncating an answer after earlier text has already reached the client.

Keep the raw path when decoding fails with `URIError`, while preserving normal decoding and line anchors. Regression coverage exercises truncated `%`, invalid `%ZZ`, incomplete UTF-8, and valid `%20` paths. The maintainer follow-up strengthens Sebastien Tardif's original fix and documents the behavior; release notes are consolidated in the final maintenance PR.

Validation on `c436038b33045c2992e2343440ac39975e9d32ba`:

- Full `npm run check` with synthetic docs/source/Gitcrawl fixtures: 1,003 workspace files; typecheck, lint, formatting, export, and smoke checks passed.
- Real local workerd HTTP run of authenticated `POST /ask-molty/api/chat`, with native upstream HTTP routed to a localhost SSE fixture. Main returned only `Hello `; the repaired Worker completed all four malformed/valid citation cases through the trailing `done`.
- No global fetch mocks or real credentials in the HTTP proof. This proves the local Worker and transport path, not a production deployment or live model output.
- Independent Codex autoreview at P2: clean.

Contributor: @SebTardif (`Sebastien Tardif <SebTardif@ncf.ca>`). Preserve their credit on squash.
